### PR TITLE
Issue#2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/c8y_test/application.properties
 test/c8y_test/debug.test
 test/c8y_test/application.setup.properties
 c8y.env
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 c8y_test/application.properties
 c8y_test/debug.test
+examples/issue#2-realtime/out.txt
+test/microservice_test/application.log
+test/microservice_test/debug.test
+test/microservice_test/application.properties

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ examples/issue#2-realtime/out.txt
 test/microservice_test/application.log
 test/microservice_test/debug.test
 test/microservice_test/application.properties
+test/c8y_test/application.properties
+test/c8y_test/debug.test
+test/c8y_test/application.setup.properties
+c8y.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch test package",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "envFile": "${workspaceFolder}/c8y.env",
+            "program": "${workspaceFolder}"
+        },
+        {
             "name": "Launch",
             "type": "go",
             "request": "launch",
@@ -12,6 +20,15 @@
             "program": "${fileDirname}",
             "env": {},
             "args": []
+        },
+        {
+            "name": "Launch Main",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+            "envFile": "${workspaceFolder}/c8y.env",
+            "args": ["main.go"]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Or, clone the repository:
 
     ```sh
     go test -timeout 30s github.com/reubenmiller/go-c8y/c8y_test
+
+    # race detector. Onlwindows use backslashes
+    go test -race -timeout 30s github.com/reubenmiller/go-c8y/test/c8y_test -run "^(TestRealtimeSubscriptions_Unsubscribe)$
     ```
 
 ## Usage

--- a/examples/issue#2-realtime/go.mod
+++ b/examples/issue#2-realtime/go.mod
@@ -1,0 +1,5 @@
+module github.com/reubenmiller/go-c8y/examples/realtime-client-simple
+
+require github.com/reubenmiller/go-c8y/pkg/c8y develop
+
+replace github.com/reubenmiller/go-c8y/pkg/c8y => ../../pkg/c8y

--- a/examples/issue#2-realtime/go.mod
+++ b/examples/issue#2-realtime/go.mod
@@ -1,5 +1,5 @@
 module github.com/reubenmiller/go-c8y/examples/realtime-client-simple
 
-require github.com/reubenmiller/go-c8y/pkg/c8y develop
+require github.com/reubenmiller/go-c8y/pkg/c8y master
 
 replace github.com/reubenmiller/go-c8y/pkg/c8y => ../../pkg/c8y

--- a/examples/issue#2-realtime/main.go
+++ b/examples/issue#2-realtime/main.go
@@ -21,8 +21,6 @@ func main() {
 		log.Fatalf("Could not connect to /cep/realtime. %s", err)
 	}
 
-	client.Realtime.WaitForConnection()
-
 	// Subscribe to all measurements
 	ch := make(chan *c8y.Message)
 	client.Realtime.Subscribe(c8y.RealtimeMeasurements("1079816599"), ch)

--- a/examples/issue#2-realtime/main.go
+++ b/examples/issue#2-realtime/main.go
@@ -32,17 +32,9 @@ func main() {
 	<-time.After(1 * time.Second)
 
 	log.Printf("Unsubscribing to all measurements")
-	client.Realtime.UnsubscribeAll()
+	client.Realtime.Unsubscribe(c8y.RealtimeMeasurements("1079816599"))
 
 	client.Realtime.Subscribe(c8y.RealtimeMeasurements("1079816599"), ch)
-	/* select {
-	case <-time.After(1 * time.Second):
-		log.Printf("Unsubscribing to all measurements")
-		client.Realtime.UnsubscribeAll()
-		return
-	} */
-
-	// client.Realtime.Subscribe(c8y.RealtimeMeasurements(), ch)
 
 	for {
 		select {

--- a/examples/issue#2-realtime/main.go
+++ b/examples/issue#2-realtime/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+)
+
+func main() {
+	// Create the client from the following environment variables
+	// C8Y_HOST, C8Y_TENANT, C8Y_USER, C8Y_PASSWORD
+	client := c8y.NewClientFromEnvironment(nil, false)
+
+	// Create realtime connection
+	err := client.Realtime.Connect()
+
+	if err != nil {
+		log.Fatalf("Could not connect to /cep/realtime. %s", err)
+	}
+
+	client.Realtime.WaitForConnection()
+
+	// Subscribe to all measurements
+	ch := make(chan *c8y.Message)
+	client.Realtime.Subscribe(c8y.RealtimeMeasurements("1079816599"), ch)
+
+	// Enable ctrl-c stop signal
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt)
+
+	<-time.After(1 * time.Second)
+
+	log.Printf("Unsubscribing to all measurements")
+	client.Realtime.UnsubscribeAll()
+
+	client.Realtime.Subscribe(c8y.RealtimeMeasurements("1079816599"), ch)
+	/* select {
+	case <-time.After(1 * time.Second):
+		log.Printf("Unsubscribing to all measurements")
+		client.Realtime.UnsubscribeAll()
+		return
+	} */
+
+	// client.Realtime.Subscribe(c8y.RealtimeMeasurements(), ch)
+
+	for {
+		select {
+		case msg := <-ch:
+			log.Printf("Received measurement. %s", msg.Payload.Data)
+
+		case <-signalCh:
+			// Enable ctrl-c to stop
+			log.Printf("Stopping realtime client")
+			return
+		}
+	}
+}

--- a/examples/issue#2-realtime/main.go
+++ b/examples/issue#2-realtime/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	// Subscribe to all measurements
 	ch := make(chan *c8y.Message)
-	client.Realtime.Subscribe(c8y.RealtimeMeasurements("1079816599"), ch)
+	<-client.Realtime.Subscribe(c8y.RealtimeMeasurements("1079816599"), ch)
 
 	// Enable ctrl-c stop signal
 	signalCh := make(chan os.Signal, 1)
@@ -31,8 +31,7 @@ func main() {
 
 	<-time.After(1 * time.Second)
 
-	log.Printf("Unsubscribing to all measurements")
-	client.Realtime.Unsubscribe(c8y.RealtimeMeasurements("1079816599"))
+	<-client.Realtime.Unsubscribe(c8y.RealtimeMeasurements("1079816599"))
 
 	client.Realtime.Subscribe(c8y.RealtimeMeasurements("1079816599"), ch)
 

--- a/examples/realtime-client-complex/main.go
+++ b/examples/realtime-client-complex/main.go
@@ -19,7 +19,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not connect to /cep/realtime. %s", err)
 	}
-	client.Realtime.WaitForConnection()
 
 	ch := make(chan *c8y.Message)
 	client.Realtime.Subscribe(c8y.RealtimeMeasurements(), ch)

--- a/examples/realtime-client-simple/main.go
+++ b/examples/realtime-client-simple/main.go
@@ -20,8 +20,6 @@ func main() {
 		log.Fatalf("Could not connect to /cep/realtime. %s", err)
 	}
 
-	client.Realtime.WaitForConnection()
-
 	// Subscribe to all measurements
 	ch := make(chan *c8y.Message)
 	client.Realtime.Subscribe(c8y.RealtimeMeasurements(), ch)

--- a/pkg/c8y/deviceCredentials.go
+++ b/pkg/c8y/deviceCredentials.go
@@ -149,6 +149,7 @@ func (s *DeviceCredentialsService) PollNewDeviceRequest(ctx context.Context, dev
 			select {
 			case <-ctx.Done():
 				err <- ctx.Err()
+				return
 
 			case <-ticker.C:
 				log.Printf("Polling for device request")
@@ -162,6 +163,7 @@ func (s *DeviceCredentialsService) PollNewDeviceRequest(ctx context.Context, dev
 
 			case <-timeoutTimer.C:
 				err <- errors.New("Timeout waiting for device request to reach ACCEPTED state")
+				return
 			}
 		}
 	}()

--- a/pkg/c8y/hub.go
+++ b/pkg/c8y/hub.go
@@ -1,0 +1,71 @@
+package c8y
+
+import "sync"
+
+// Hub maintains the set of active subscriptions and broadcasts messages to the clients.
+type Hub struct {
+	// Registered clients.
+	clients map[*subscription]bool
+
+	// Inbound messages from the clients.
+	broadcast chan *Message
+
+	// Register requests from the clients.
+	register chan *subscription
+
+	// Unregister requests from clients by channel name.
+	unregister chan string
+
+	// Return a channel of channels
+	getChannels chan chan string
+
+	// Called when a client is removed
+	onRemove func(string)
+
+	channels sync.Map
+}
+
+func newHub() *Hub {
+	return &Hub{
+		broadcast:  make(chan *Message),
+		register:   make(chan *subscription),
+		unregister: make(chan string),
+		clients:    make(map[*subscription]bool),
+
+		getChannels: make(chan chan string),
+	}
+}
+
+// GetActiveChannels returns the list of active channels which are currently subscribed to
+func (h *Hub) GetActiveChannels() []string {
+	channels := []string{}
+	h.channels.Range(func(key, value interface{}) bool {
+		channels = append(channels, key.(string))
+		return true
+	})
+	return channels
+}
+
+func (h *Hub) run() {
+	for {
+		select {
+		case client := <-h.register:
+			h.clients[client] = true
+			h.channels.Store(client.glob.String(), true)
+		case channel := <-h.unregister:
+			// Delete clients with the same channel pattern
+			h.channels.Delete(channel)
+			for client := range h.clients {
+				if client.glob.String() == channel {
+					delete(h.clients, client)
+				}
+			}
+		case message := <-h.broadcast:
+			for client := range h.clients {
+				if client.glob.String() == message.Channel && !client.disabled {
+					client.out <- message
+				}
+			}
+		}
+	}
+}

--- a/pkg/c8y/realtime.go
+++ b/pkg/c8y/realtime.go
@@ -167,8 +167,6 @@ func NewRealtimeClient(host string, wsDialer *websocket.Dialer, tenant, username
 		tenant:   tenant,
 		username: username,
 		password: password,
-
-		heartbeatInterval: 10 * time.Minute,
 	}
 }
 

--- a/pkg/microservice/subscriptions.go
+++ b/pkg/microservice/subscriptions.go
@@ -2,6 +2,7 @@ package microservice
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"regexp"
 
@@ -56,8 +57,9 @@ func (m *Microservice) SubscribeToNotifications(user c8y.ServiceUser, realtimeCh
 		return errors.New("Failed to retrieve valid realtime client")
 	}
 
-	realtime.Connect()
-	realtime.WaitForConnection()
+	if err := realtime.Connect(); err != nil {
+		return fmt.Errorf("Failed to connect. %s", err)
+	}
 	ch := make(chan *c8y.Message)
 
 	err = realtime.Subscribe(realtimeChannel, ch)
@@ -69,7 +71,6 @@ func (m *Microservice) SubscribeToNotifications(user c8y.ServiceUser, realtimeCh
 		for {
 			select {
 			case msg := <-ch:
-				// zap.S().Infof("ws: [frame]: %s\n", string(msg.Payload.Item.Raw))
 				if onMessageFunc != nil {
 					onMessageFunc(msg)
 				}

--- a/pkg/microservice/subscriptions.go
+++ b/pkg/microservice/subscriptions.go
@@ -62,7 +62,7 @@ func (m *Microservice) SubscribeToNotifications(user c8y.ServiceUser, realtimeCh
 	}
 	ch := make(chan *c8y.Message)
 
-	err = realtime.Subscribe(realtimeChannel, ch)
+	err = <-realtime.Subscribe(realtimeChannel, ch)
 
 	go func() {
 		defer func() {

--- a/test/c8y_test/appplication_test.go
+++ b/test/c8y_test/appplication_test.go
@@ -58,11 +58,13 @@ func TestApplicationService_GetApplicationsByOwner(t *testing.T) {
 		client.TenantName,
 		nil,
 	)
-	minApplications := 1
+	minApplications := 0
 	testingutils.Ok(t, err)
 	testingutils.Equals(t, http.StatusOK, resp.StatusCode)
 	testingutils.Assert(t, len(data.Items) >= minApplications, "Unexpected amount of applications found. want >=%d, got: %d", minApplications, len(data.Items))
-	testingutils.Assert(t, data.Applications[0].Name != "", "Application should have a name")
+	if minApplications > 0 {
+		testingutils.Assert(t, data.Applications[0].Name != "", "Application should have a name")
+	}
 }
 
 func TestApplicationService_GetApplicationsByTenant(t *testing.T) {

--- a/test/c8y_test/realtime_test.go
+++ b/test/c8y_test/realtime_test.go
@@ -11,6 +11,26 @@ import (
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 )
 
+func OperationSenderFactory(client *c8y.Client, deviceID string, t *testing.T) func() {
+	return func() {
+		_, _, err := client.Operation.Create(
+			context.Background(),
+			map[string]interface{}{
+				"deviceId": deviceID,
+				"test_operation": map[string]interface{}{
+					"name": "test operation",
+					"parameters": map[string]interface{}{
+						"value1": 1,
+					},
+				},
+			},
+		)
+		if err != nil {
+			t.Errorf("Failed to create operation. %s", err)
+		}
+	}
+}
+
 func TestRealtimeClient(t *testing.T) {
 	client := createTestClient()
 	realtime := client.Realtime
@@ -176,10 +196,17 @@ func TestRealtimeSubscriptions_SubscribeToMeasurements(t *testing.T) {
 
 	defer func() {
 		close(ch)
-		realtime.Close()
+		// realtime.Close()
 	}()
 
 	msgCount := 0
+
+	/* go func() {
+		select {
+		case <- time.After(5 * time.Second):
+			realtime.Disconnect()
+		}
+	}() */
 
 	for {
 		select {
@@ -204,10 +231,109 @@ func TestRealtimeSubscriptions_SubscribeToMeasurements(t *testing.T) {
 
 		case <-timerChan:
 			realtime.UnsubscribeAll()
+			time.Sleep(5 * time.Second)
+			realtime.Disconnect()
 
 			testingutils.Equals(t, 2, msgCount)
-			realtime.Close()
+			time.Sleep(10 * time.Second)
+			// realtime.Close()
 			return
 		}
+	}
+}
+
+func TestRealtimeSubscriptions_Unsubscribe(t *testing.T) {
+	// Issue #2: https://github.com/reubenmiller/go-c8y/issues/2
+	// A subscribe -> unsubscribe -> subscribe should not result in duplicate
+	// items on the channel
+	// https://www.ardanlabs.com/blog/2017/10/the-behavior-of-channels.html
+	device, err := createRandomTestDevice()
+
+	if err != nil {
+		t.Errorf("Device should exist. wanted nil, got %s", err)
+	}
+
+	client := createTestClient()
+	realtime := client.Realtime
+
+	// Create a dummy operation
+	sendOperation := OperationSenderFactory(client, device.ID, t)
+
+	realtime.Connect()
+	err = realtime.WaitForConnection(30 * time.Second)
+	// time.Sleep(2 * time.Second)
+
+	if err != nil {
+		t.Errorf("Client failed to connect to server. %s", err)
+	}
+
+	ch := make(chan *c8y.Message)
+	timerChan := time.NewTimer(time.Second * 20).C
+
+	done := make(chan bool)
+	msgCount := 0
+
+	go func() {
+		expectedOpName := "test operation"
+		for {
+			select {
+			case msg := <-ch:
+				msgCount++
+
+				if msg.Payload.RealtimeAction != "CREATE" {
+					t.Errorf("Unexpected realtime action type. wanted: CREATE, got: %s", msg.Payload.RealtimeAction)
+				}
+
+				opName := msg.Payload.Item.Get("test_operation.name").String()
+				if opName != expectedOpName {
+					t.Errorf("Unexpected operation name. wanted: %s, got: %s", expectedOpName, opName)
+				}
+
+				deviceId := msg.Payload.Item.Get("deviceId").String()
+				if deviceId != device.ID {
+					t.Errorf("Unexpected device id in operation. wanted: %s, got: %s", device.ID, deviceId)
+				}
+				log.Printf("ws: [frame]: Channel: %s, %s\n", msg.Channel, string(msg.Payload.Item.Raw))
+
+			case <-timerChan:
+				// Stop subscribing to operations after x seconds, and then compare the result
+				realtime.UnsubscribeAll()
+
+				time.Sleep(2 * time.Second)
+
+				log.Printf("Test: Closing realtime client")
+				realtime.Close()
+				done <- true
+				return
+			}
+		}
+	}()
+
+	subcriptionPattern := c8y.RealtimeOperations(device.ID)
+	realtime.Subscribe(subcriptionPattern, ch)
+	realtime.WaitForPendingSubscribe()
+
+	// Unsubscribe then resubscribe, this should not lead to duplicated messages
+	realtime.Unsubscribe(subcriptionPattern)
+	realtime.WaitForPendingUnsubscribe()
+
+	sendOperation() // Subscription should not count as the sub
+
+	time.Sleep(2 * time.Second)
+	realtime.Subscribe(subcriptionPattern, ch)
+	realtime.WaitForPendingSubscribe()
+
+	sendOperation()
+	sendOperation()
+
+	defer func() {
+		log.Printf("Test: Closing channel")
+		close(ch)
+	}()
+
+	// Wait for done signal, then check the total message count
+	<-done
+	if msgCount != 2 {
+		t.Errorf("Unexpected message count. wanted: 2, got: %d", msgCount)
 	}
 }

--- a/test/c8y_test/realtime_test.go
+++ b/test/c8y_test/realtime_test.go
@@ -290,17 +290,17 @@ func TestRealtimeSubscriptions_Unsubscribe(t *testing.T) {
 
 	subcriptionPattern := c8y.RealtimeOperations(device.ID)
 
-	err = realtime.Subscribe(subcriptionPattern, ch)
+	err = <-realtime.Subscribe(subcriptionPattern, ch)
 	testingutils.Ok(t, err)
 
 	// Unsubscribe then resubscribe, this should not lead to duplicated messages
-	err = realtime.Unsubscribe(subcriptionPattern)
+	err = <-realtime.Unsubscribe(subcriptionPattern)
 	testingutils.Ok(t, err)
 
 	sendOperation() // Subscription should not count as the sub
 
 	time.Sleep(2 * time.Second)
-	err = realtime.Subscribe(subcriptionPattern, ch)
+	err = <-realtime.Subscribe(subcriptionPattern, ch)
 	testingutils.Ok(t, err)
 
 	sendOperation()

--- a/test/c8y_test/realtime_test.go
+++ b/test/c8y_test/realtime_test.go
@@ -37,12 +37,6 @@ func TestRealtimeClient(t *testing.T) {
 
 	err := realtime.Connect()
 	testingutils.Ok(t, err)
-
-	err = realtime.WaitForConnection()
-
-	if err != nil {
-		t.Errorf("Unknown error")
-	}
 }
 
 func TestRealtimeSubscriptions_SubscribeToOperations(t *testing.T) {
@@ -54,12 +48,9 @@ func TestRealtimeSubscriptions_SubscribeToOperations(t *testing.T) {
 
 	client := createTestClient()
 	realtime := client.Realtime
+	err = realtime.Connect()
+	testingutils.Ok(t, err)
 
-	go func() {
-		realtime.Connect()
-	}()
-
-	err = realtime.WaitForConnection()
 	time.Sleep(5 * time.Second)
 
 	if err != nil {
@@ -146,15 +137,8 @@ func TestRealtimeSubscriptions_SubscribeToMeasurements(t *testing.T) {
 	client := createTestClient()
 	realtime := client.Realtime
 
-	go func() {
-		realtime.Connect()
-	}()
-
-	err = realtime.WaitForConnection()
-
-	if err != nil {
-		t.Errorf("Unknown error")
-	}
+	err = realtime.Connect()
+	testingutils.Ok(t, err)
 
 	ch := make(chan *c8y.Message)
 
@@ -259,16 +243,11 @@ func TestRealtimeSubscriptions_Unsubscribe(t *testing.T) {
 	// Create a dummy operation
 	sendOperation := OperationSenderFactory(client, device.ID, t)
 
-	realtime.Connect()
-	err = realtime.WaitForConnection(30 * time.Second)
-	// time.Sleep(2 * time.Second)
-
-	if err != nil {
-		t.Errorf("Client failed to connect to server. %s", err)
-	}
+	err = realtime.Connect()
+	testingutils.Ok(t, err)
 
 	ch := make(chan *c8y.Message)
-	timerChan := time.NewTimer(time.Second * 20).C
+	timerChan := time.NewTimer(time.Second * 15).C
 
 	done := make(chan bool)
 	msgCount := 0
@@ -310,18 +289,19 @@ func TestRealtimeSubscriptions_Unsubscribe(t *testing.T) {
 	}()
 
 	subcriptionPattern := c8y.RealtimeOperations(device.ID)
-	realtime.Subscribe(subcriptionPattern, ch)
-	realtime.WaitForPendingSubscribe()
+
+	err = realtime.Subscribe(subcriptionPattern, ch)
+	testingutils.Ok(t, err)
 
 	// Unsubscribe then resubscribe, this should not lead to duplicated messages
-	realtime.Unsubscribe(subcriptionPattern)
-	realtime.WaitForPendingUnsubscribe()
+	err = realtime.Unsubscribe(subcriptionPattern)
+	testingutils.Ok(t, err)
 
 	sendOperation() // Subscription should not count as the sub
 
 	time.Sleep(2 * time.Second)
-	realtime.Subscribe(subcriptionPattern, ch)
-	realtime.WaitForPendingSubscribe()
+	err = realtime.Subscribe(subcriptionPattern, ch)
+	testingutils.Ok(t, err)
 
 	sendOperation()
 	sendOperation()


### PR DESCRIPTION
# Changes
## Realtime client
* Fixes #2 by adding Bayeux heartbeat message (/meta/connect) to stop the client timeout after 2 hours
* Added connection retry logic (with simple back off algorithm. When the connection is re-established, then all of the subscriptions will be resent automatically
* Sending intermittent websocket ping messages to test if the websocket is still alive

## PollNewDeviceRequest 
* Fixed bug where the timeout would not stop the polling go routine
