### PR TITLE
update realtime notification url for websockets according to 10.10.0 …

### DIFF
--- a/pkg/c8y/realtime.go
+++ b/pkg/c8y/realtime.go
@@ -30,7 +30,7 @@ const (
 	// MINIMUMVERSION supported Bayeux version
 	MINIMUMVERSION = "1.0"
 
-	// MinimumRetryDelay is the minimum retry delay in milliseconds to wait before sending another /connect/meta message
+	// MinimumRetryDelay is the minimum retry delay in milliseconds to wait before sending another /meta/connect message
 	MinimumRetryDelay int64 = 500
 )
 
@@ -166,7 +166,7 @@ func getRealtimeURL(host string) *url.URL {
 		c8yhost.Scheme = "wss"
 	}
 
-	c8yhost.Path = "/cep/realtime"
+	c8yhost.Path = "/notification/realtime"
 
 	return c8yhost
 }


### PR DESCRIPTION
hi!
the url seems to be changed from _**/cep/realtime**_ to **_/notifications/realtime_**. It was done at least at 10.9.0
https://cumulocity.com/api/#section/Handshake/Request-example

Anyway, it seems that old path is still valid.