### PR TITLE
Support configuring notification2 websocket ping/pong intervals and timeouts

### DIFF
--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -266,6 +266,7 @@ func (c *Notification2Client) connect() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	ws.SetReadDeadline(time.Now().Add(60 * time.Second))
 	c.ws = ws
 	if c.tomb == nil {
 		c.tomb = &tomb.Tomb{}

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -41,7 +41,7 @@ const (
 const (
 	writeWait = 10 * time.Second
 
-	pongWait = 300 * time.Second
+	pongWait = 30 * time.Second
 
 	pingPeriod = (pongWait * 9) / 10
 )

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -402,7 +402,7 @@ func (c *Notification2Client) worker() error {
 		for {
 			messageType, rawMessage, err := c.ws.ReadMessage()
 
-			Logger.Debugf("Received message: %s", rawMessage)
+			Logger.Debugf("Received message: type=%d, message=%s, err=%s", messageType, rawMessage, err)
 
 			if err != nil {
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -125,7 +125,7 @@ func NewNotification2Client(host string, wsDialer *websocket.Dialer, subscriptio
 		wsDialer = &websocket.Dialer{
 			Proxy:             http.ProxyFromEnvironment,
 			HandshakeTimeout:  45 * time.Second,
-			EnableCompression: false,
+			EnableCompression: true,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -289,7 +289,6 @@ func (c *Notification2Client) connect() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	ws.SetReadDeadline(time.Now().Add(60 * time.Second))
 	c.ws = ws
 	if c.tomb == nil {
 		c.tomb = &tomb.Tomb{}
@@ -389,11 +388,6 @@ func (c *Notification2Client) worker() error {
 	c.ws.SetPongHandler(func(appData string) error {
 		Logger.Debugf("Pong handler. %v", appData)
 		c.ws.SetReadDeadline(time.Now().Add(c.Options.GetPongDuration()))
-		return nil
-	})
-
-	c.ws.SetPingHandler(func(appData string) error {
-		Logger.Debugf("Ping handler. %v", appData)
 		return nil
 	})
 

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -47,9 +47,10 @@ func SetLogger(log logger.Logger) {
 }
 
 type Notification2ClientOptions struct {
-	PingPeriod time.Duration
-	PongWait   time.Duration
-	WriteWait  time.Duration
+	// Send pings to client with this interval. Must be less than pongWait.
+	PingInterval time.Duration
+	PongWait     time.Duration
+	WriteWait    time.Duration
 }
 
 func (o *Notification2ClientOptions) GetWriteDuration() time.Duration {
@@ -67,10 +68,10 @@ func (o *Notification2ClientOptions) GetPongDuration() time.Duration {
 }
 
 func (o *Notification2ClientOptions) GetPingDuration() time.Duration {
-	if o.PingPeriod == 0 {
+	if o.PingInterval == 0 {
 		return 60 * time.Second
 	}
-	return o.PingPeriod
+	return o.PingInterval
 }
 
 // Notification2Client is a client used for the notification2 interface

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -223,8 +223,10 @@ func (c *Notification2Client) createWebsocket() (*websocket.Conn, error) {
 	ws, _, err := c.dialer.Dial(c.URL(), nil)
 
 	if err != nil {
+		Logger.Warnf("Failed to establish connection. %s", err)
 		return ws, err
 	}
+	Logger.Debugf("Established websocket connection. %s", err)
 	return ws, nil
 }
 
@@ -363,8 +365,14 @@ func (c *Notification2Client) SendMessageAck(messageIdentifier []byte) error {
 func (c *Notification2Client) worker() error {
 	done := make(chan struct{})
 
-	c.ws.SetPongHandler(func(string) error {
+	c.ws.SetPongHandler(func(appData string) error {
+		Logger.Debugf("Pong handler. %v", appData)
 		c.ws.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+
+	c.ws.SetPingHandler(func(appData string) error {
+		Logger.Debugf("Ping handler. %v", appData)
 		return nil
 	})
 

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -356,7 +356,7 @@ func (c *Notification2Client) writeHandler() {
 			if c.ws != nil {
 				// A websocket ping should initiate a websocket pong response from the server
 				// If the pong is not received in the minimum time, then the connection will be reset
-				c.ws.SetWriteDeadline(time.Now().Add(c.Options.GetWriteDuration()))
+				// c.ws.SetWriteDeadline(time.Now().Add(c.Options.GetWriteDuration()))
 				if err := c.ws.WriteMessage(websocket.PingMessage, nil); err != nil {
 					Logger.Warnf("Failed to send ping message to server. %s", err)
 					// go c.reconnect()

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -124,7 +124,7 @@ func NewNotification2Client(host string, wsDialer *websocket.Dialer, subscriptio
 		// Default client ignores self signed certificates (to enable compatibility to the edge which uses self signed certs)
 		wsDialer = &websocket.Dialer{
 			Proxy:             http.ProxyFromEnvironment,
-			HandshakeTimeout:  10 * time.Second,
+			HandshakeTimeout:  45 * time.Second,
 			EnableCompression: false,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -108,7 +108,7 @@ func getEndpoint(host string, subscription Subscription) *url.URL {
 		fullHost = "wss" + host[index:]
 	}
 	c8yhost, _ := url.Parse(fullHost)
-	c8yhost.Path = "/notification2/consumer/"
+	c8yhost.Path = "/notification2/consumer"
 	c8yhost.RawQuery = "token=" + subscription.Token
 
 	if subscription.Consumer != "" {

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -108,7 +108,7 @@ func getEndpoint(host string, subscription Subscription) *url.URL {
 		fullHost = "wss" + host[index:]
 	}
 	c8yhost, _ := url.Parse(fullHost)
-	c8yhost.Path = "/notification2/consumer"
+	c8yhost.Path = "/notification2/consumer/"
 	c8yhost.RawQuery = "token=" + subscription.Token
 
 	if subscription.Consumer != "" {

--- a/pkg/c8y/notification2service.go
+++ b/pkg/c8y/notification2service.go
@@ -169,9 +169,10 @@ func (s *Notification2Service) DeleteSubscriptionBySource(ctx context.Context, o
 }
 
 type Notification2ClientOptions struct {
-	Token    string
-	Consumer string
-	Options  Notification2TokenOptions
+	Token             string
+	Consumer          string
+	Options           Notification2TokenOptions
+	ConnectionOptions notification2.ConnectionOptions
 }
 
 type Notification2TokenClaim struct {
@@ -325,7 +326,7 @@ func (s *Notification2Service) RenewToken(ctx context.Context, opt Notification2
 //	}
 //
 // ```
-func (s *Notification2Service) CreateClient(ctx context.Context, opt Notification2ClientOptions, websocketOpts notification2.Notification2ClientOptions) (*notification2.Notification2Client, error) {
+func (s *Notification2Service) CreateClient(ctx context.Context, opt Notification2ClientOptions) (*notification2.Notification2Client, error) {
 	// Validate token against expected subscriptions
 	token, err := s.RenewToken(ctx, opt)
 	if err != nil {
@@ -340,6 +341,6 @@ func (s *Notification2Service) CreateClient(ctx context.Context, opt Notificatio
 		},
 		Consumer: opt.Consumer,
 		Token:    token,
-	}, websocketOpts)
+	}, opt.ConnectionOptions)
 	return client, nil
 }

--- a/pkg/c8y/notification2service.go
+++ b/pkg/c8y/notification2service.go
@@ -288,40 +288,44 @@ func (s *Notification2Service) RenewToken(ctx context.Context, opt Notification2
 
 // Create a notification2 client to subscribe to new options
 //
-// Example
+// # Example
 //
 // ```
-// notifClient, err := client.Notification2.CreateClient(context.Background(), c8y.Notification2ClientOptions{
-//     Token:    os.Getenv("NOTIFICATION2_TOKEN"),
-//     Consumer: *consumer,
-//     Options: &c8y.Notification2TokenOptions{
-//     	   ExpiresInMinutes: 2,
-//     	   Subscription:     *subscription,
-//     	   Subscriber:       *subscriber,
-//     },
-// })
-// if err != nil {
-//     panic(err)
-// }
+//
+//	notifClient, err := client.Notification2.CreateClient(context.Background(), c8y.Notification2ClientOptions{
+//	    Token:    os.Getenv("NOTIFICATION2_TOKEN"),
+//	    Consumer: *consumer,
+//	    Options: &c8y.Notification2TokenOptions{
+//	    	   ExpiresInMinutes: 2,
+//	    	   Subscription:     *subscription,
+//	    	   Subscriber:       *subscriber,
+//	    },
+//	})
+//
+//	if err != nil {
+//	    panic(err)
+//	}
+//
 // messagesCh := make(chan notifications2.Message)
 // notifClient.Register("*", messagesCh)
 // signalCh := make(chan os.Signal, 1)
 // signal.Notify(signalCh, os.Interrupt)
 //
-// for {
-//   select {
-//   case msg := <-messagesCh:
-//	      log.Printf("Received message. %s", msg.Payload)
-//        notifClient.SendMessageAck(msg.Identifier)
+//	for {
+//	  select {
+//	  case msg := <-messagesCh:
+//		      log.Printf("Received message. %s", msg.Payload)
+//	       notifClient.SendMessageAck(msg.Identifier)
 //
-//   case <-signalCh:
-//   	// Enable ctrl-c to stop
-//   	notificationClient.Close()
-//   	return
-//   }
-// }
+//	  case <-signalCh:
+//	  	// Enable ctrl-c to stop
+//	  	notificationClient.Close()
+//	  	return
+//	  }
+//	}
+//
 // ```
-func (s *Notification2Service) CreateClient(ctx context.Context, opt Notification2ClientOptions) (*notification2.Notification2Client, error) {
+func (s *Notification2Service) CreateClient(ctx context.Context, opt Notification2ClientOptions, websocketOpts notification2.Notification2ClientOptions) (*notification2.Notification2Client, error) {
 	// Validate token against expected subscriptions
 	token, err := s.RenewToken(ctx, opt)
 	if err != nil {
@@ -336,6 +340,6 @@ func (s *Notification2Service) CreateClient(ctx context.Context, opt Notificatio
 		},
 		Consumer: opt.Consumer,
 		Token:    token,
-	})
+	}, websocketOpts)
 	return client, nil
 }


### PR DESCRIPTION
The following improvements were made to the notification2 service:

* Control ping interval and pong timeouts
* Increase handshake timeout to 45 seconds
* Support configuring skip ssl verification (insecure mode)
* Set write deadlines before writing to websocket