### PR TITLE
feat: record overall request duration (approximate)

### DIFF
--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/go-querystring/query"
 	"github.com/reubenmiller/go-c8y/pkg/jsonUtilities"
@@ -1009,7 +1010,9 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}, middl
 		}
 	}
 
+	start := time.Now()
 	resp, err := c.client.Do(req)
+	duration := time.Since(start)
 	if err != nil {
 		// If we got an error, and the context has been canceled,
 		// the context's error is probably more useful.
@@ -1031,7 +1034,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}, middl
 		return nil, err
 	}
 
-	response := newResponse(resp)
+	response := newResponse(resp, duration)
 
 	err = CheckResponse(resp)
 	if err != nil {

--- a/pkg/c8y/response.go
+++ b/pkg/c8y/response.go
@@ -12,8 +12,8 @@ import (
 
 // newResponse creates a new Response for the provided http.Response.
 // r must not be nil.
-func newResponse(r *http.Response) *Response {
-	response := &Response{Response: r}
+func newResponse(r *http.Response, duration time.Duration) *Response {
+	response := &Response{Response: r, duration: duration}
 	return response
 }
 
@@ -28,6 +28,11 @@ type Response struct {
 	body       []byte
 	size       int64
 	receivedAt time.Time
+	duration   time.Duration
+}
+
+func (r *Response) Duration() time.Duration {
+	return r.duration
 }
 
 func (r *Response) SetBody(v []byte) {


### PR DESCRIPTION
Add a new `.Duration` property to the `c8y.Response` struct to allow users to easily retrieve the estimated request duration.