### PR TITLE
fix: remove duplicated tenant version code

### DIFF
--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -99,6 +99,9 @@ type Client struct {
 	// Cumulocity Tenant
 	TenantName string
 
+	// Cumulocity Version
+	Version string
+
 	// Password for Cumulocity Authentication
 	Password string
 
@@ -946,6 +949,12 @@ func (c *Client) LoginUsingOAuth2(ctx context.Context, initRequest ...string) er
 	if err != nil {
 		return err
 	}
+
+	// Get Cumulocity system version, but don't fail if it does not work
+	if version, err := c.TenantOptions.GetVersion(ctx); err == nil {
+		c.Version = version
+	}
+
 	c.TenantName = tenant.Name
 	return nil
 }
@@ -955,15 +964,6 @@ func (c *Client) SetRequestOptions(options DefaultRequestOptions) {
 	c.clientMu.Lock()
 	defer c.clientMu.Unlock()
 	c.requestOptions = options
-}
-
-// Get the current tenant version
-func (c *Client) GetTenantVersion(ctx context.Context) (string, error) {
-	option, _, err := c.TenantOptions.GetOption(ctx, "system", "version")
-	if err != nil {
-		return "", err
-	}
-	return option.Value, nil
 }
 
 func withContext(ctx context.Context, req *http.Request) *http.Request {

--- a/pkg/c8y/tenantOptions.go
+++ b/pkg/c8y/tenantOptions.go
@@ -147,6 +147,10 @@ func (s *TenantOptionsService) GetSystemOption(ctx context.Context, category, ke
 }
 
 // GetVersion returns Cumulocity version information
-func (s *TenantOptionsService) GetVersion(ctx context.Context) (*TenantOption, *Response, error) {
-	return s.GetSystemOption(ctx, "system", "version")
+func (s *TenantOptionsService) GetVersion(ctx context.Context) (string, error) {
+	opt, _, err := s.GetSystemOption(ctx, "system", "version")
+	if err != nil {
+		return "", err
+	}
+	return opt.Value, nil
 }


### PR DESCRIPTION
Revert GetTenantVersion changes as it was duplicated.