### PR TITLE
feat: improve notification2 logging

### DIFF
--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
-	"fmt"
 	"math"
 	"net/http"
 	"net/url"
@@ -185,7 +184,8 @@ func (c *Notification2Client) Connect() error {
 }
 
 func (c *Notification2Client) Endpoint() string {
-	return fmt.Sprintf("%s%s", c.url.Host, c.url.Path)
+	// TODO: Support the hide senstive information option
+	return c.url.String()
 }
 
 func (c *Notification2Client) URL() string {

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -184,7 +184,7 @@ func (c *Notification2Client) Connect() error {
 }
 
 func (c *Notification2Client) Endpoint() string {
-	// TODO: Support the hide senstive information option
+	// TODO: Support hiding of sensitive information (same as the client)
 	return c.url.String()
 }
 

--- a/pkg/c8y/notification2service.go
+++ b/pkg/c8y/notification2service.go
@@ -178,7 +178,12 @@ type Notification2ClientOptions struct {
 type Notification2TokenClaim struct {
 	Subscriber string `json:"sub,omitempty"`
 	Topic      string `json:"topic,omitempty"`
+	Shared     string `json:"shared,omitempty"`
 	jwt.RegisteredClaims
+}
+
+func (c *Notification2TokenClaim) IsShared() bool {
+	return strings.EqualFold(c.Shared, "true")
 }
 
 func (c *Notification2TokenClaim) Tenant() string {
@@ -224,6 +229,7 @@ func (s *Notification2Service) RenewToken(ctx context.Context, opt Notification2
 	subscription := opt.Options.Subscription
 	subscriber := opt.Options.Subscriber
 	expiresInMinutes := opt.Options.ExpiresInMinutes
+	shared := opt.Options.Shared
 
 	if opt.Token != "" {
 
@@ -257,6 +263,8 @@ func (s *Notification2Service) RenewToken(ctx context.Context, opt Notification2
 			subscriber = claims.Subscriber
 		}
 
+		shared = claims.IsShared()
+
 		if claimMatch && expiresInMinutes == 0 {
 			// Reuse the expiration time given in the token
 			if claims.ExpiresAt != nil && claims.IssuedAt != nil {
@@ -280,6 +288,7 @@ func (s *Notification2Service) RenewToken(ctx context.Context, opt Notification2
 		ExpiresInMinutes: expiresInMinutes,
 		Subscription:     subscription,
 		Subscriber:       subscriber,
+		Shared:           shared,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Include websocket information about the connection in the debug log entries.