### PR TITLE
feat: add support for futher application filter options

### DIFF
--- a/pkg/c8y/application.go
+++ b/pkg/c8y/application.go
@@ -16,7 +16,14 @@ type ApplicationService service
 type ApplicationOptions struct {
 	PaginationOptions
 
-	Type string `url:"type,omitempty"`
+	Name        string `url:"name,omitempty"`
+	Owner       string `url:"owner,omitempty"`
+	ProviderFor string `url:"providerFor,omitempty"`
+	Subscriber  string `url:"subscriber,omitempty"`
+	Tenant      string `url:"tenant,omitempty"`
+	Type        string `url:"type,omitempty"`
+	User        string `url:"user,omitempty"`
+	HasVersions bool   `url:"hasVersions,omitempty"`
 }
 
 // Cumulocity Application Types


### PR DESCRIPTION
Add support for additional query parameters when requesting a list of applications as per https://cumulocity.com/api/core/#operation/getAbstractApplicationCollectionResource