### PR TITLE
fix: support using fixed url path prefixes for websocket communication

### DIFF
--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -128,14 +128,16 @@ func getEndpoint(host string, subscription Subscription) *url.URL {
 	if index := strings.Index(host, "://"); index > -1 {
 		fullHost = "wss" + host[index:]
 	}
-	c8yhost, _ := url.Parse(fullHost)
-	c8yhost.Path = "/notification2/consumer/"
+	tempUrl, err := url.Parse(fullHost)
+	if err != nil {
+		Logger.Fatalf("Invalid url. %s", err)
+	}
+	c8yhost := tempUrl.ResolveReference(&url.URL{Path: "notification2/consumer/"})
 	c8yhost.RawQuery = "token=" + subscription.Token
 
 	if subscription.Consumer != "" {
 		c8yhost.RawQuery += "&consumer=" + subscription.Consumer
 	}
-
 	return c8yhost
 }
 

--- a/pkg/c8y/notification2service.go
+++ b/pkg/c8y/notification2service.go
@@ -342,7 +342,7 @@ func (s *Notification2Service) CreateClient(ctx context.Context, opt Notificatio
 		return nil, err
 	}
 
-	client := notification2.NewNotification2Client(s.client.BaseURL.Host, nil, notification2.Subscription{
+	client := notification2.NewNotification2Client(s.client.BaseURL.String(), nil, notification2.Subscription{
 		TokenRenewal: func(v string) (string, error) {
 			return s.RenewToken(ctx, Notification2ClientOptions{
 				Token: v,

--- a/pkg/c8y/realtime.go
+++ b/pkg/c8y/realtime.go
@@ -188,9 +188,7 @@ func getRealtimeURL(host string) *url.URL {
 		c8yhost.Scheme = "wss"
 	}
 
-	c8yhost.Path = "/cep/realtime"
-
-	return c8yhost
+	return c8yhost.ResolveReference(&url.URL{Path: "cep/realtime"})
 }
 
 // NewRealtimeClient initializes a new Bayeux client. By default `http.DefaultClient`


### PR DESCRIPTION
When using a c8y host which includes a fixed path, then the fix path element should be used when building any relative paths.

For example:

```
http://localhost:8001/c8y
```

Should be translated to

```
http://localhost:8001/c8y/cep/realtime
```

When trying to establish a bayeux client to the realtime endpoint.

Relates to: https://github.com/reubenmiller/go-c8y-cli/issues/335