### PR TITLE
test: enable test which deletes an event

### DIFF
--- a/test/c8y_test/event_test.go
+++ b/test/c8y_test/event_test.go
@@ -105,7 +105,6 @@ func TestEventService_Update(t *testing.T) {
 }
 
 func TestEventService_Delete(t *testing.T) {
-	t.Skip("Skipping due to ci issue on 1020.40.0 on staging latest. https://cumulocity.atlassian.net/browse/MTM-57310")
 	client := createTestClient()
 
 	testDevice, err := createRandomTestDevice()


### PR DESCRIPTION
The root cause was located. It was previously failing due to a notification2 subscription queue was full/out of resources