### PR TITLE
feat! Add deprecation notices to measurement API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
+	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/viper v1.18.2
 	github.com/tidwall/gjson v1.17.0
 	github.com/vbauerster/mpb/v6 v6.0.4

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
+github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/internal/pkg/testingutils/rand.go
+++ b/internal/pkg/testingutils/rand.go
@@ -3,6 +3,8 @@ package testingutils
 import (
 	"math/rand"
 	"time"
+
+	"github.com/sethvargo/go-password/password"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyz" +
@@ -21,4 +23,15 @@ func stringWithCharset(length int, charset string) string {
 // RandomString returns a random string of the given length
 func RandomString(length int) string {
 	return stringWithCharset(length, charset)
+}
+
+// RandomPassword generate a random password that meets the default
+// Cumulocity IoT password policy
+func RandomPassword(length int) string {
+	value, err := password.Generate(length, 10, 10, false, false)
+	if err != nil {
+		// Panic as this should not happen
+		panic("could not generate password")
+	}
+	return value
 }

--- a/pkg/c8y/measurement.go
+++ b/pkg/c8y/measurement.go
@@ -303,7 +303,9 @@ func (s *MeasurementService) GetMeasurementSeries(ctx context.Context, opt *Meas
 	return data, resp, nil
 }
 
-// GetMeasurement returns a single measurement
+// Deprecated: GetMeasurement returns a single measurement
+// Note: Retieving single measurements is no longer supported in Cumulocity IoT
+// when using the time series feature. Use GetMeasurements() instead
 func (s *MeasurementService) GetMeasurement(ctx context.Context, ID string) (*Measurement, *Response, error) {
 	data := new(Measurement)
 	resp, err := s.client.SendRequest(ctx, RequestOptions{
@@ -314,7 +316,9 @@ func (s *MeasurementService) GetMeasurement(ctx context.Context, ID string) (*Me
 	return data, resp, err
 }
 
-// Delete removed a measurement by ID
+// Deprecated: Delete removed a measurement by ID
+// Note: Deleting single measurements is no longer supported in Cumulocity IoT
+// when using the time series feature. Use DeleteMeasurements() instead
 func (s *MeasurementService) Delete(ctx context.Context, ID string) (*Response, error) {
 	return s.client.SendRequest(ctx, RequestOptions{
 		Method: "DELETE",

--- a/pkg/c8y/measurement.go
+++ b/pkg/c8y/measurement.go
@@ -303,9 +303,9 @@ func (s *MeasurementService) GetMeasurementSeries(ctx context.Context, opt *Meas
 	return data, resp, nil
 }
 
-// Deprecated: GetMeasurement returns a single measurement
-// Note: Retieving single measurements is no longer supported in Cumulocity IoT
-// when using the time series feature. Use GetMeasurements() instead
+// GetMeasurement returns a single measurement
+// Deprecated: Retrieving single measurements is no longer supported in Cumulocity IoT
+// when using the time series feature. Use `GetMeasurements` instead
 func (s *MeasurementService) GetMeasurement(ctx context.Context, ID string) (*Measurement, *Response, error) {
 	data := new(Measurement)
 	resp, err := s.client.SendRequest(ctx, RequestOptions{
@@ -316,9 +316,9 @@ func (s *MeasurementService) GetMeasurement(ctx context.Context, ID string) (*Me
 	return data, resp, err
 }
 
-// Deprecated: Delete removed a measurement by ID
-// Note: Deleting single measurements is no longer supported in Cumulocity IoT
-// when using the time series feature. Use DeleteMeasurements() instead
+// Delete removed a measurement by ID
+// Deprecated: Deleting single measurements is no longer supported in Cumulocity IoT
+// when using the time series feature. Use `DeleteMeasurements` instead
 func (s *MeasurementService) Delete(ctx context.Context, ID string) (*Response, error) {
 	return s.client.SendRequest(ctx, RequestOptions{
 		Method: "DELETE",

--- a/test/c8y_test/measurement_test.go
+++ b/test/c8y_test/measurement_test.go
@@ -346,7 +346,7 @@ func TestMeasurementService_CreateWithDifferentTypes(t *testing.T) {
 }
 
 func TestMeasurementService_GetMeasurement(t *testing.T) {
-	// Note: Removing single measurements is no longer supported by Cumulocity IoT
+	t.Skip("Note: Removing single measurements is no longer supported by Cumulocity IoT")
 	client := createTestClient()
 	testDevice, err := createRandomTestDevice()
 	testingutils.Ok(t, err)
@@ -425,7 +425,7 @@ func TestMeasurementService_DeleteMeasurements(t *testing.T) {
 		searchOptions,
 	)
 
-	testingutils.Assert(t, err != nil, "Error should not be nil")
+	testingutils.Ok(t, err)
 	testingutils.Equals(t, http.StatusOK, resp.StatusCode())
 	testingutils.Equals(t, 0, len(measColAfter.Measurements))
 }

--- a/test/c8y_test/measurement_test.go
+++ b/test/c8y_test/measurement_test.go
@@ -345,7 +345,8 @@ func TestMeasurementService_CreateWithDifferentTypes(t *testing.T) {
 	// createMeasurement(false)
 }
 
-func TestMeasurementService_GetMeasurement_DeleteMeasurement(t *testing.T) {
+func TestMeasurementService_GetMeasurement(t *testing.T) {
+	// Note: Removing single measurements is no longer supported by Cumulocity IoT
 	client := createTestClient()
 	testDevice, err := createRandomTestDevice()
 	testingutils.Ok(t, err)
@@ -373,24 +374,6 @@ func TestMeasurementService_GetMeasurement_DeleteMeasurement(t *testing.T) {
 	testingutils.Ok(t, err)
 	testingutils.Equals(t, http.StatusOK, resp.StatusCode())
 	testingutils.Equals(t, meas.ID, meas2.ID)
-
-	// Remove measurement
-	resp, err = client.Measurement.Delete(
-		context.Background(),
-		meas2.ID,
-	)
-
-	testingutils.Ok(t, err)
-	testingutils.Equals(t, http.StatusNoContent, resp.StatusCode())
-
-	// Check if the measurement has been deleted
-	meas3, resp, err := client.Measurement.GetMeasurement(
-		context.Background(),
-		meas2.ID,
-	)
-	testingutils.Assert(t, err != nil, "Error should not be nil")
-	testingutils.Equals(t, http.StatusNotFound, resp.StatusCode())
-	testingutils.Assert(t, meas3.ID == "", "ID should be empty when the object is not found")
 }
 
 func TestMeasurementService_DeleteMeasurements(t *testing.T) {
@@ -435,22 +418,16 @@ func TestMeasurementService_DeleteMeasurements(t *testing.T) {
 	testingutils.Equals(t, http.StatusNoContent, resp.StatusCode())
 
 	// Check that the measurements have been removed
-	deletedMeas1, resp, err := client.Measurement.GetMeasurement(
+	// Check by requesting the new collection again as retrieving single measurements
+	// is no longer supported by Cumulocity IoT
+	measColAfter, resp, err := client.Measurement.GetMeasurements(
 		context.Background(),
-		meas1.ID,
+		searchOptions,
 	)
-	testingutils.Assert(t, err != nil, "Error should not be nil")
-	testingutils.Equals(t, http.StatusNotFound, resp.StatusCode())
-	testingutils.Equals(t, "", deletedMeas1.ID)
 
-	// Check that the measurements have been removed
-	deletedMeas2, resp, err := client.Measurement.GetMeasurement(
-		context.Background(),
-		meas1.ID,
-	)
 	testingutils.Assert(t, err != nil, "Error should not be nil")
-	testingutils.Equals(t, http.StatusNotFound, resp.StatusCode())
-	testingutils.Equals(t, "", deletedMeas2.ID)
+	testingutils.Equals(t, http.StatusOK, resp.StatusCode())
+	testingutils.Equals(t, 0, len(measColAfter.Measurements))
 }
 
 func TestMeasurementService_CreateMeasurements(t *testing.T) {

--- a/test/c8y_test/user_test.go
+++ b/test/c8y_test/user_test.go
@@ -53,7 +53,7 @@ func TestUserService_GetUserByUsername(t *testing.T) {
 func TestUserService_CRUD(t *testing.T) {
 	client := createTestClient()
 	name := "myciuser" + testingutils.RandomString(7)
-	password := testingutils.RandomString(32)
+	password := testingutils.RandomPassword(32)
 	userInput := c8y.NewUser(name, name+"@no-reply.org", password)
 	userInput.
 		SetFirstName("User01").


### PR DESCRIPTION
The `GetMeasurement` and `Delete` measurement api has been deprecated as Cumulocity IoT no longer supports these API requests when the time series feature is enabled.

The calls will still be sent to the platform, however users should look at alternatives (e.g. delete or get collection of measurements).