### PR TITLE
feat: support ui extension management

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       C8Y_TIMEOUT: 30000
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+          # skip caching due to golangci-lint errors during setup
+          # see https://github.com/golangci/golangci-lint-action/issues/807
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
 
   test:
     runs-on: ${{ matrix.os }}
@@ -47,7 +49,7 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - name: Install Task
-      uses: arduino/setup-task@v1
+      uses: arduino/setup-task@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests

--- a/internal/pkg/testingutils/testingutils.go
+++ b/internal/pkg/testingutils/testingutils.go
@@ -47,6 +47,22 @@ func Equals(tb testing.TB, exp, act interface{}) {
 	}
 }
 
+// Check if a string is found in a given slice of strings
+func ContainsString(tb testing.TB, exp string, act []string) {
+	found := false
+	for _, v := range act {
+		if v == exp {
+			found = true
+			break
+		}
+	}
+	if !found {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
+	}
+}
+
 // FileEquals fails if the SHA256 checksum of the exp if not equal to the checksum of the act
 func FileEquals(tb testing.TB, exp, act string) {
 	expSHA, _ := getSHA256(exp)

--- a/pkg/c8y/application.go
+++ b/pkg/c8y/application.go
@@ -43,6 +43,7 @@ const (
 const (
 	ApplicationAvailabilityMarket  = "MARKET"
 	ApplicationAvailabilityPrivate = "PRIVATE"
+	ApplicationAvailabilityShared  = "SHARED"
 )
 
 // Application todo

--- a/pkg/c8y/applicationVersions.go
+++ b/pkg/c8y/applicationVersions.go
@@ -1,0 +1,194 @@
+package c8y
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+var ContentTypeApplicationVersion = "application/vnd.com.nsn.cumulocity.applicationVersion+json"
+var ContentTypeApplicationVersionCollection = "application/vnd.com.nsn.cumulocity.applicationVersionCollection+json"
+
+// ApplicationService provides the service provider for the Cumulocity Application API
+type ApplicationVersionsService service
+
+// ApplicationVersionsOptions options that can be provided when using application api calls
+type ApplicationVersionsOptions struct {
+	PaginationOptions
+
+	Name         string `url:"name,omitempty"`
+	Owner        string `url:"owner,omitempty"`
+	ProviderFor  string `url:"providerFor,omitempty"`
+	Subscriber   string `url:"subscriber,omitempty"`
+	Tenant       string `url:"tenant,omitempty"`
+	Type         string `url:"type,omitempty"`
+	User         string `url:"user,omitempty"`
+	Availability string `url:"availability,omitempty"`
+	HasVersions  *bool  `url:"hasVersions,omitempty"`
+}
+
+func (o *ApplicationVersionsOptions) WithHasVersions(v bool) *ApplicationVersionsOptions {
+	o.HasVersions = &v
+	return o
+}
+
+// Application version
+type ApplicationVersion struct {
+	Version  string   `json:"version,omitempty"`
+	BinaryID string   `json:"binaryId,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
+
+	Application *Application `json:"-,omitempty"`
+
+	Item gjson.Result `json:"-"`
+}
+
+// ApplicationVersionsCollection a list of versions related to an application
+type ApplicationVersionsCollection struct {
+	*BaseResponse
+
+	Versions []ApplicationVersion `json:"applicationVersions"`
+
+	Items []gjson.Result `json:"-"`
+}
+
+// Retrieve the selected version of an application in your tenant using the tag
+func (s *ApplicationVersionsService) GetVersionByTag(ctx context.Context, ID string, tag string) (*ApplicationVersion, *Response, error) {
+	data := new(ApplicationVersion)
+	resp, err := s.client.SendRequest(ctx, RequestOptions{
+		Method: "GET",
+		Path:   "application/applications/" + ID + "/versions",
+		Accept: ContentTypeApplicationVersion,
+		Query: &versionOption{
+			Tag: tag,
+		},
+		ResponseData: data,
+	})
+	return data, resp, err
+}
+
+// Retrieve the selected version of an application in your tenant using the version name
+func (s *ApplicationVersionsService) GetVersionByName(ctx context.Context, ID string, version string) (*ApplicationVersion, *Response, error) {
+	data := new(ApplicationVersion)
+	resp, err := s.client.SendRequest(ctx, RequestOptions{
+		Method: "GET",
+		Path:   "application/applications/" + ID + "/versions",
+		Accept: ContentTypeApplicationVersion,
+		Query: &versionOption{
+			Version: version,
+		},
+		ResponseData: data,
+	})
+	return data, resp, err
+}
+
+// Retrieve all versions of an application in your tenant
+func (s *ApplicationVersionsService) GetVersions(ctx context.Context, ID string, opt *ApplicationVersionsOptions) (*ApplicationVersionsCollection, *Response, error) {
+	data := new(ApplicationVersionsCollection)
+	resp, err := s.client.SendRequest(ctx, RequestOptions{
+		Method:       "GET",
+		Path:         "application/applications/" + ID + "/versions",
+		Query:        opt,
+		ResponseData: data,
+	})
+	return data, resp, err
+}
+
+// Replaces the tags of a given application version in your tenant
+func (s *ApplicationVersionsService) ReplaceTags(ctx context.Context, ID string, version string, tags []string) (*ApplicationVersion, *Response, error) {
+	data := new(ApplicationVersion)
+	resp, err := s.client.SendRequest(ctx, RequestOptions{
+		Method: "PUT",
+		Path:   "application/applications/" + ID + "/versions/" + version,
+		Accept: ContentTypeApplicationVersion,
+		Body: &ApplicationVersion{
+			Tags: tags,
+		},
+		ResponseData: data,
+	})
+	return data, resp, err
+}
+
+// Delete removes an application version by the tag
+func (s *ApplicationVersionsService) DeleteVersionByTag(ctx context.Context, ID string, tag string) (*Response, error) {
+	return s.client.SendRequest(ctx, RequestOptions{
+		Method: "DELETE",
+		Path:   "application/applications/" + ID + "/versions",
+		Query: &versionOption{
+			Tag: tag,
+		},
+	})
+}
+
+type versionOption struct {
+	Tag     string `url:"tag,omitempty"`
+	Version string `url:"version,omitempty"`
+}
+
+// Delete removes an application version by the version name
+func (s *ApplicationVersionsService) DeleteVersionByName(ctx context.Context, ID string, version string) (*Response, error) {
+	return s.client.SendRequest(ctx, RequestOptions{
+		Method: "DELETE",
+		Path:   "application/applications/" + ID + "/versions",
+		Query: &versionOption{
+			Version: version,
+		},
+	})
+}
+
+func (s *ApplicationVersionsService) IsUrl(u string) bool {
+	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
+}
+
+// CreateVersion creates a new version of an application from a given file or url
+func (s *ApplicationVersionsService) CreateVersion(ctx context.Context, ID string, filenameOrURL string, version ApplicationVersion) (*ApplicationVersion, *Response, error) {
+	var file *os.File
+	var err error
+	if s.IsUrl(filenameOrURL) {
+		urlLink := filenameOrURL
+		file, err = os.CreateTemp("", "extension.zip")
+		resp, err := http.Get(urlLink)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to download extension from url. %w", err)
+		}
+		defer func() {
+			resp.Body.Close()
+			file.Close()
+			_ = os.Remove(file.Name())
+		}()
+		if _, err := io.Copy(file, resp.Body); err != nil {
+			return nil, nil, fmt.Errorf("failed to write extension to file. %w", err)
+		}
+	} else {
+		file, err = os.Open(filenameOrURL)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	applicationVersion, err := json.Marshal(version)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	values := map[string]io.Reader{
+		"applicationBinary":  file,
+		"applicationVersion": bytes.NewBuffer(applicationVersion),
+	}
+	data := new(ApplicationVersion)
+	resp, err := s.client.SendRequest(ctx, RequestOptions{
+		Method:       "POST",
+		Accept:       ContentTypeApplicationVersion,
+		Path:         "/application/applications/" + ID + "/versions",
+		FormData:     values,
+		ResponseData: data,
+	})
+	return data, resp, err
+}

--- a/pkg/c8y/applicationVersions.go
+++ b/pkg/c8y/applicationVersions.go
@@ -17,6 +17,7 @@ var ContentTypeApplicationVersion = "application/vnd.com.nsn.cumulocity.applicat
 var ContentTypeApplicationVersionCollection = "application/vnd.com.nsn.cumulocity.applicationVersionCollection+json"
 
 // ApplicationService provides the service provider for the Cumulocity Application API
+// WARNING: THE UI Extension Service API is not yet finalized so expect changes in the future!
 type ApplicationVersionsService service
 
 // ApplicationVersionsOptions options that can be provided when using application api calls

--- a/pkg/c8y/applicationVersions.go
+++ b/pkg/c8y/applicationVersions.go
@@ -154,17 +154,20 @@ func (s *ApplicationVersionsService) CreateVersion(ctx context.Context, ID strin
 	if s.IsUrl(filenameOrURL) {
 		urlLink := filenameOrURL
 		file, err = os.CreateTemp("", "extension.zip")
-		resp, err := http.Get(urlLink)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to download extension from url. %w", err)
+			return nil, nil, fmt.Errorf("could not create temp file. %w", err)
+		}
+		resp, downloadErr := http.Get(urlLink)
+		if downloadErr != nil {
+			return nil, nil, fmt.Errorf("failed to download extension from url. %w", downloadErr)
 		}
 		defer func() {
 			resp.Body.Close()
 			file.Close()
 			_ = os.Remove(file.Name())
 		}()
-		if _, err := io.Copy(file, resp.Body); err != nil {
-			return nil, nil, fmt.Errorf("failed to write extension to file. %w", err)
+		if _, writeErr := io.Copy(file, resp.Body); writeErr != nil {
+			return nil, nil, fmt.Errorf("failed to write extension to file. %w", writeErr)
 		}
 	} else {
 		file, err = os.Open(filenameOrURL)

--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -128,25 +128,27 @@ type Client struct {
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
 	// Services used for talking to different parts of the Cumulocity API.
-	Context           *ContextService
-	Alarm             *AlarmService
-	Audit             *AuditService
-	DeviceCredentials *DeviceCredentialsService
-	Measurement       *MeasurementService
-	Operation         *OperationService
-	Tenant            *TenantService
-	Event             *EventService
-	Inventory         *InventoryService
-	Application       *ApplicationService
-	Identity          *IdentityService
-	Microservice      *MicroserviceService
-	Notification2     *Notification2Service
-	Retention         *RetentionRuleService
-	TenantOptions     *TenantOptionsService
-	Software          *InventorySoftwareService
-	Firmware          *InventoryFirmwareService
-	User              *UserService
-	DeviceCertificate *DeviceCertificateService
+	Context             *ContextService
+	Alarm               *AlarmService
+	Audit               *AuditService
+	DeviceCredentials   *DeviceCredentialsService
+	Measurement         *MeasurementService
+	Operation           *OperationService
+	Tenant              *TenantService
+	Event               *EventService
+	Inventory           *InventoryService
+	Application         *ApplicationService
+	UIExtension         *UIExtensionService
+	ApplicationVersions *ApplicationVersionsService
+	Identity            *IdentityService
+	Microservice        *MicroserviceService
+	Notification2       *Notification2Service
+	Retention           *RetentionRuleService
+	TenantOptions       *TenantOptionsService
+	Software            *InventorySoftwareService
+	Firmware            *InventoryFirmwareService
+	User                *UserService
+	DeviceCertificate   *DeviceCertificateService
 }
 
 const (
@@ -337,6 +339,8 @@ func NewClient(httpClient *http.Client, baseURL string, tenant string, username 
 	c.Event = (*EventService)(&c.common)
 	c.Inventory = (*InventoryService)(&c.common)
 	c.Application = (*ApplicationService)(&c.common)
+	c.ApplicationVersions = (*ApplicationVersionsService)(&c.common)
+	c.UIExtension = (*UIExtensionService)(&c.common)
 	c.Identity = (*IdentityService)(&c.common)
 	c.Microservice = (*MicroserviceService)(&c.common)
 	c.Notification2 = (*Notification2Service)(&c.common)
@@ -705,7 +709,8 @@ func (c *Client) SetJSONItems(resp *Response, v interface{}) error {
 		t.Item = resp.JSON()
 	case *ApplicationCollection:
 		t.Items = resp.JSON("applications").Array()
-
+	case *ApplicationVersionsCollection:
+		t.Items = resp.JSON("applicationVersions").Array()
 	case *AuditRecord:
 		t.Item = resp.JSON()
 	case *AuditRecordCollection:

--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -803,7 +803,6 @@ func (c *Client) NewRequest(method, path string, query string, body interface{})
 	}
 
 	c.SetAuthorization(req)
-	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.UserAgent)
 	req.Header.Set("X-APPLICATION", "go-client")
 	c.SetHostHeader(req)
@@ -871,7 +870,6 @@ func (c *Client) NewRequestWithoutAuth(method, path string, query string, body i
 		}
 	}
 
-	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.UserAgent)
 	req.Header.Set("X-APPLICATION", "go-client")
 	c.SetHostHeader(req)

--- a/pkg/c8y/uiExtension.go
+++ b/pkg/c8y/uiExtension.go
@@ -144,9 +144,9 @@ func (s *UIExtensionService) CreateExtension(ctx context.Context, application *A
 	} else if application.Name != "" {
 		// Lookup via name
 		opts := &ApplicationOptions{}
-		matches, resp, err := s.client.Application.GetApplicationsByName(ctx, application.Name, opts.WithHasVersions(true))
-		if err != nil {
-			return nil, resp, err
+		matches, listResp, listErr := s.client.Application.GetApplicationsByName(ctx, application.Name, opts.WithHasVersions(true))
+		if listErr != nil {
+			return nil, listResp, listErr
 		}
 		if len(matches.Applications) > 0 {
 			app = &matches.Applications[0]

--- a/pkg/c8y/uiExtension.go
+++ b/pkg/c8y/uiExtension.go
@@ -10,6 +10,7 @@ import (
 )
 
 // UIExtensionService to managed UI extensions
+// WARNING: THE UI Extension Service API is not yet finalized so expect changes in the future!
 type UIExtensionService service
 
 type UIExtension struct {

--- a/pkg/c8y/uiExtension.go
+++ b/pkg/c8y/uiExtension.go
@@ -1,0 +1,231 @@
+package c8y
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// UIExtensionService to managed UI extensions
+type UIExtensionService service
+
+type UIExtension struct {
+	Application
+	Manifest     *UIManifest     `json:"manifest,omitempty"`
+	ManifestFile *UIManifestFile `json:"-"`
+}
+
+type UIManifest struct {
+	Package   string `json:"package,omitempty"`
+	IsPackage *bool  `json:"isPackage,omitempty"`
+}
+
+func (m *UIManifest) WithIsPackage(v bool) *UIManifest {
+	m.IsPackage = &v
+	return m
+}
+func (m *UIManifest) WithPackage(v string) *UIManifest {
+	m.Package = v
+	return m
+}
+
+type UIManifestFile struct {
+	Name        string `json:"name,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Key         string `json:"key,omitempty"`
+	ContextPath string `json:"contextPath,omitempty"`
+	Description string `json:"description,omitempty"`
+	Package     string `json:"package,omitempty"`
+	IsPackage   bool   `json:"isPackage,omitempty"`
+}
+
+const CumulocityUIManifestFile = "cumulocity.json"
+
+func NewUIExtension(name string) *UIExtension {
+	ext := &UIExtension{
+		Application: Application{
+			Name:        name,
+			Key:         name + "-key",
+			ContextPath: name,
+			Type:        "HOSTED",
+		},
+		Manifest: &UIManifest{},
+	}
+	ext.Manifest.
+		WithIsPackage(true).
+		WithPackage("plugin")
+	return ext
+}
+
+func GetUIExtensionManifestContents(zipFilename string, contents interface{}) error {
+	reader, err := zip.OpenReader(zipFilename)
+	if err != nil {
+		return err
+	}
+
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		// check if the file matches the name for application portfolio xml
+		if strings.EqualFold(file.Name, CumulocityUIManifestFile) {
+			rc, err := file.Open()
+			if err != nil {
+				return err
+			}
+
+			buf := new(bytes.Buffer)
+			if _, err := buf.ReadFrom(rc); err != nil {
+				return err
+			}
+
+			defer rc.Close()
+
+			// Unmarshal bytes
+			if err := json.Unmarshal(buf.Bytes(), &contents); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *UIExtensionService) NewUIExtensionFromFile(filename string) (*UIExtension, error) {
+	app := &UIExtension{
+		Manifest:     &UIManifest{},
+		ManifestFile: &UIManifestFile{},
+	}
+	err := GetUIExtensionManifestContents(filename, app.ManifestFile)
+
+	app.Name = app.ManifestFile.Name
+	app.Key = app.ManifestFile.Key
+	app.Type = ApplicationTypeHosted
+	app.ContextPath = app.ManifestFile.ContextPath
+	app.Manifest.WithIsPackage(app.ManifestFile.IsPackage)
+	app.Manifest.WithPackage(app.ManifestFile.Package)
+	return app, err
+}
+
+func NewApplicationExtension(name string) *UIExtension {
+	app := &UIExtension{
+		Application: Application{
+			Name:        name,
+			Key:         name + "-key",
+			ContextPath: name,
+			Type:        ApplicationTypeHosted,
+		},
+		Manifest: &UIManifest{},
+	}
+	app.Manifest.WithIsPackage(true)
+	app.Manifest.WithPackage("package")
+
+	return app
+}
+
+type UpsertOptions struct {
+	SkipActivation bool
+	Version        *ApplicationVersion
+}
+
+// CreateVersion creates a new version of an application from a given file
+func (s *UIExtensionService) CreateExtension(ctx context.Context, application *Application, filename string, opt UpsertOptions) (*ApplicationVersion, *Response, error) {
+	var app *Application
+	var resp *Response
+	var err error
+
+	// Check if application already exits
+	if application.ID != "" {
+		// No need to look it up
+		app = &Application{
+			ID: application.ID,
+		}
+	} else if application.Name != "" {
+		// Lookup via name
+		opts := &ApplicationOptions{}
+		matches, resp, err := s.client.Application.GetApplicationsByName(ctx, application.Name, opts.WithHasVersions(true))
+		if err != nil {
+			return nil, resp, err
+		}
+		if len(matches.Applications) > 0 {
+			app = &matches.Applications[0]
+		}
+	} else {
+		return nil, nil, fmt.Errorf("application must have either the .ID or .Name set")
+	}
+
+	if app == nil {
+		// Create the new application
+		app, resp, err = s.client.Application.Create(ctx, application)
+	} else {
+		// Update the existing application
+		props := &Application{}
+		if application.Availability != "" {
+			props.Availability = application.Availability
+		}
+		app, resp, err = s.client.Application.Update(ctx, app.ID, props)
+	}
+	if err != nil {
+		return nil, resp, err
+	}
+
+	// Upload binary
+	binaryVersion, resp, err := s.client.ApplicationVersions.CreateVersion(ctx, app.ID, filename, *opt.Version)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if binaryVersion != nil {
+		// Store a reference to the related application
+		binaryVersion.Application = app
+	}
+
+	// Activate the version
+	if !opt.SkipActivation {
+		_, resp, err = s.client.Application.Update(ctx, app.ID, &Application{
+			ActiveVersionID: binaryVersion.BinaryID,
+		})
+		if err != nil {
+			return binaryVersion, resp, err
+		}
+	}
+
+	return binaryVersion, resp, err
+}
+
+func (s *UIExtensionService) SetActive(ctx context.Context, appID string, binaryID string) (*Application, *Response, error) {
+	return s.client.Application.Update(ctx, appID, &Application{
+		ActiveVersionID: binaryID,
+	})
+}
+
+type ExtensionOptions struct {
+	PaginationOptions
+
+	Name         string `url:"name,omitempty"`
+	Owner        string `url:"owner,omitempty"`
+	Availability string `url:"availability,omitempty"`
+	ProviderFor  string `url:"providerFor,omitempty"`
+	Subscriber   string `url:"subscriber,omitempty"`
+	Tenant       string `url:"tenant,omitempty"`
+	Type         string `url:"type,omitempty"`
+	User         string `url:"user,omitempty"`
+	HasVersions  bool   `url:"hasVersions,omitempty"`
+}
+
+// GetVersions returns a list of versions for a given application
+func (s *UIExtensionService) GetExtensions(ctx context.Context, opt *ExtensionOptions) (*ApplicationCollection, *Response, error) {
+	data := new(ApplicationCollection)
+	if opt == nil {
+		opt = &ExtensionOptions{}
+	}
+	opt.HasVersions = true
+	resp, err := s.client.SendRequest(ctx, RequestOptions{
+		Method:       "GET",
+		Path:         "application/applications",
+		Query:        opt,
+		ResponseData: data,
+	})
+	return data, resp, err
+}

--- a/test/c8y_test/applicationVersions_test.go
+++ b/test/c8y_test/applicationVersions_test.go
@@ -1,0 +1,202 @@
+package c8y_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/reubenmiller/go-c8y/internal/pkg/testingutils"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+)
+
+var uiExampleExtension = "https://github.com/SoftwareAG/cumulocity-remote-access-cloud-http-proxy/releases/download/v2.5.0/cloud-http-proxy-ui.zip"
+
+func createTestExtension(t *testing.T, client *c8y.Client, version *c8y.ApplicationVersion) *c8y.Application {
+	appName := testingutils.RandomString(12)
+	appOptions := c8y.NewApplicationExtension(appName)
+	app, _, err := client.Application.Create(context.Background(), &appOptions.Application)
+	testingutils.Ok(t, err)
+
+	_, _, err = client.ApplicationVersions.CreateVersion(context.Background(), app.ID, uiExampleExtension, *version)
+	testingutils.Ok(t, err)
+
+	t.Cleanup(func() {
+		client.Application.Delete(context.Background(), app.ID)
+	})
+
+	return app
+}
+
+func downloadFile(u string, out io.WriteCloser) error {
+	defer out.Close()
+	resp, err := http.Get(u)
+	if err != nil {
+		return fmt.Errorf("failed to download extension from url. %w", err)
+	}
+	defer resp.Body.Close()
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+// CreateTempFile creates a file which will be cleaned up at the end of the test
+func CreateTempFile(t *testing.T, name string) *os.File {
+	file, err := os.CreateTemp("", "*_"+name)
+	testingutils.Ok(t, err)
+	t.Cleanup(func() {
+		file.Close()
+		os.Remove(file.Name())
+	})
+	return file
+}
+
+func TestApplicationVersionsService_GetVersions(t *testing.T) {
+	client := createTestClient()
+	app := createTestExtension(t, client, &c8y.ApplicationVersion{
+		Version: "1.0.0",
+		Tags:    []string{"latest"},
+	})
+	apps, resp, err := client.ApplicationVersions.GetVersions(
+		context.Background(),
+		app.ID,
+		&c8y.ApplicationVersionsOptions{
+			PaginationOptions: c8y.PaginationOptions{
+				PageSize: 10,
+			},
+		},
+	)
+
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, http.StatusOK, resp.StatusCode())
+	testingutils.Assert(t, len(apps.Versions) > 0, "At least one application version should be found")
+	testingutils.Assert(t, apps.Versions[0].Version == "1.0.0", "Version should be set")
+	testingutils.Assert(t, len(apps.Versions[0].Tags) == 1, "Tags should be present")
+	testingutils.Assert(t, apps.Versions[0].Tags[0] == "latest", "Tag should be set")
+}
+
+func TestApplicationVersionsService_GetVersionByTag(t *testing.T) {
+	client := createTestClient()
+	app := createTestExtension(t, client, &c8y.ApplicationVersion{
+		Version: "1.0.1",
+		Tags:    []string{"latest", "tag1"},
+	})
+
+	data, resp, err := client.ApplicationVersions.GetVersionByTag(
+		context.Background(),
+		app.ID,
+		"tag1",
+	)
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, http.StatusOK, resp.StatusCode())
+	testingutils.Equals(t, data.Version, "1.0.1")
+	testingutils.Equals(t, 2, len(data.Tags))
+	testingutils.ContainsString(t, "latest", data.Tags)
+	testingutils.ContainsString(t, "tag1", data.Tags)
+}
+
+func TestApplicationVersionsService_GetVersionByName(t *testing.T) {
+	client := createTestClient()
+	app := createTestExtension(t, client, &c8y.ApplicationVersion{
+		Version: "1.0.2",
+		Tags:    []string{"tag1"},
+	})
+
+	data, resp, err := client.ApplicationVersions.GetVersionByName(
+		context.Background(),
+		app.ID,
+		"1.0.2",
+	)
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, http.StatusOK, resp.StatusCode())
+	testingutils.Equals(t, data.Version, "1.0.2")
+	testingutils.Equals(t, 2, len(data.Tags))
+	testingutils.ContainsString(t, "latest", data.Tags) // Latest is automatically added when it is activated
+	testingutils.ContainsString(t, "tag1", data.Tags)
+}
+
+func TestApplicationVersionsService_CRUD_Extension(t *testing.T) {
+	client := createTestClient()
+
+	file := CreateTempFile(t, "exampleExtension.zip")
+
+	err := downloadFile(uiExampleExtension, file)
+	testingutils.Ok(t, err)
+
+	app, err := client.UIExtension.NewUIExtensionFromFile(file.Name())
+	testingutils.Ok(t, err)
+
+	// Delete application if it already exists
+	appCol, _, err := client.UIExtension.GetExtensions(
+		context.Background(),
+		&c8y.ExtensionOptions{
+			Name:              app.Name,
+			PaginationOptions: *c8y.NewPaginationOptions(10),
+		},
+	)
+	testingutils.Ok(t, err)
+	if len(appCol.Applications) > 0 {
+		for _, app := range appCol.Applications {
+			_, tErr := client.Application.Delete(context.Background(), app.ID)
+			testingutils.Ok(t, tErr)
+		}
+	}
+
+	//
+	// Create
+	appVersion, resp, err := client.UIExtension.CreateExtension(context.Background(), &app.Application, file.Name(), c8y.UpsertOptions{
+		SkipActivation: false,
+		Version: &c8y.ApplicationVersion{
+			Version: app.ManifestFile.Version,
+			Tags:    []string{"latest", "tag1"},
+		},
+	})
+
+	testingutils.Ok(t, err)
+	testingutils.Assert(t, http.StatusCreated == resp.StatusCode() || http.StatusOK == resp.StatusCode(), "Status code is ok")
+	testingutils.Equals(t, appVersion.Version, app.ManifestFile.Version)
+	testingutils.Equals(t, 2, len(appVersion.Tags))
+	testingutils.ContainsString(t, "latest", appVersion.Tags)
+	testingutils.ContainsString(t, "tag1", appVersion.Tags)
+
+	// Create second version
+	appVersion2, resp, err := client.UIExtension.CreateExtension(context.Background(), &app.Application, file.Name(), c8y.UpsertOptions{
+		SkipActivation: false,
+		Version: &c8y.ApplicationVersion{
+			Version: "2.5.1",
+			Tags:    []string{"latest", "tagA"},
+		},
+	})
+	testingutils.Ok(t, err)
+	testingutils.Assert(t, http.StatusCreated == resp.StatusCode() || http.StatusOK == resp.StatusCode(), "Status code is ok")
+	testingutils.Equals(t, appVersion2.Version, "2.5.1")
+	testingutils.Equals(t, 2, len(appVersion2.Tags))
+	testingutils.ContainsString(t, "latest", appVersion2.Tags)
+	testingutils.ContainsString(t, "taga", appVersion2.Tags) // Tags are lowercased by the platform
+
+	// Update?
+	updatedVersion, resp, err := client.ApplicationVersions.ReplaceTags(context.Background(), appVersion.Application.ID, app.ManifestFile.Version, []string{"tag2", "tag3"})
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, http.StatusOK, resp.StatusCode())
+	testingutils.Equals(t, 2, len(updatedVersion.Tags))
+	testingutils.ContainsString(t, "tag2", updatedVersion.Tags)
+	testingutils.ContainsString(t, "tag3", updatedVersion.Tags)
+
+	_, _, err = client.UIExtension.SetActive(context.Background(), appVersion.Application.ID, "")
+	testingutils.Ok(t, err)
+
+	//
+	// Delete by version (the non active version)
+	resp, err = client.ApplicationVersions.DeleteVersionByName(
+		context.Background(),
+		appVersion.Application.ID,
+		appVersion.Version,
+	)
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, http.StatusNoContent, resp.StatusCode())
+
+	//
+	// Delete by tag
+	// TODO
+}

--- a/test/c8y_test/applicationVersions_test.go
+++ b/test/c8y_test/applicationVersions_test.go
@@ -129,6 +129,7 @@ func TestApplicationVersionsService_CRUD_Extension(t *testing.T) {
 
 	// Use a unique name
 	app.Name = testingutils.RandomString(12)
+	app.Key = app.Name + "-key"
 
 	//
 	// Create

--- a/test/c8y_test/applicationVersions_test.go
+++ b/test/c8y_test/applicationVersions_test.go
@@ -130,6 +130,7 @@ func TestApplicationVersionsService_CRUD_Extension(t *testing.T) {
 	// Use a unique name
 	app.Name = testingutils.RandomString(12)
 	app.Key = app.Name + "-key"
+	app.ContextPath = app.Name
 
 	//
 	// Create
@@ -144,7 +145,9 @@ func TestApplicationVersionsService_CRUD_Extension(t *testing.T) {
 	t.Cleanup(func() {
 		// Don't check if it failed or not, as the test will also delete the application
 		// but this cleanup is done just in case the test fails earlier
-		client.Application.Delete(context.Background(), appVersion.Application.ID)
+		if appVersion != nil && appVersion.Application != nil {
+			client.Application.Delete(context.Background(), appVersion.Application.ID)
+		}
 	})
 
 	testingutils.Ok(t, err)

--- a/test/c8y_test/applicationVersions_test.go
+++ b/test/c8y_test/applicationVersions_test.go
@@ -127,21 +127,8 @@ func TestApplicationVersionsService_CRUD_Extension(t *testing.T) {
 	app, err := client.UIExtension.NewUIExtensionFromFile(file.Name())
 	testingutils.Ok(t, err)
 
-	// Delete application if it already exists
-	appCol, _, err := client.UIExtension.GetExtensions(
-		context.Background(),
-		&c8y.ExtensionOptions{
-			Name:              app.Name,
-			PaginationOptions: *c8y.NewPaginationOptions(10),
-		},
-	)
-	testingutils.Ok(t, err)
-	if len(appCol.Applications) > 0 {
-		for _, app := range appCol.Applications {
-			_, tErr := client.Application.Delete(context.Background(), app.ID)
-			testingutils.Ok(t, tErr)
-		}
-	}
+	// Use a unique name
+	app.Name = testingutils.RandomString(12)
 
 	//
 	// Create
@@ -151,6 +138,12 @@ func TestApplicationVersionsService_CRUD_Extension(t *testing.T) {
 			Version: app.ManifestFile.Version,
 			Tags:    []string{"latest", "tag1"},
 		},
+	})
+
+	t.Cleanup(func() {
+		// Don't check if it failed or not, as the test will also delete the application
+		// but this cleanup is done just in case the test fails earlier
+		client.Application.Delete(context.Background(), appVersion.Application.ID)
 	})
 
 	testingutils.Ok(t, err)

--- a/test/c8y_test/uiExtension_test.go
+++ b/test/c8y_test/uiExtension_test.go
@@ -31,6 +31,7 @@ func TestUIExtensionService_CreateExtension(t *testing.T) {
 	// Use unique name to avoid name clashes
 	app1.Name = appName
 	app1.Key = appName + "-key"
+	app1.ContextPath = app1.Name
 	testingutils.Ok(t, err)
 
 	appVersion1, _, err := client.UIExtension.CreateExtension(context.Background(), &app1.Application, file1.Name(), c8y.UpsertOptions{

--- a/test/c8y_test/uiExtension_test.go
+++ b/test/c8y_test/uiExtension_test.go
@@ -1,0 +1,68 @@
+package c8y_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reubenmiller/go-c8y/internal/pkg/testingutils"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+)
+
+var uiExtensionURLApp1Version1 = "https://github.com/SoftwareAG/cumulocity-remote-access-cloud-http-proxy/releases/download/v2.4.3/cloud-http-proxy-ui.zip"
+var uiExtensionURLApp1Version2 = "https://github.com/SoftwareAG/cumulocity-remote-access-cloud-http-proxy/releases/download/v2.5.0/cloud-http-proxy-ui.zip"
+
+func TestUIExtensionService_CreateExtension(t *testing.T) {
+	client := createTestClient()
+
+	var err error
+
+	appName := testingutils.RandomString(12)
+
+	//
+	// Version 1
+	file1 := CreateTempFile(t, "exampleExtension1.zip")
+	err = downloadFile(uiExtensionURLApp1Version1, file1)
+	testingutils.Ok(t, err)
+
+	app1, err := client.UIExtension.NewUIExtensionFromFile(file1.Name())
+	testingutils.Assert(t, app1.Name != "", "Name should not be empty")
+
+	// Use unique name to avoid name clashes
+	app1.Name = appName
+	testingutils.Ok(t, err)
+
+	appVersion1, _, err := client.UIExtension.CreateExtension(context.Background(), &app1.Application, file1.Name(), c8y.UpsertOptions{
+		SkipActivation: false,
+		Version: &c8y.ApplicationVersion{
+			Version: app1.ManifestFile.Version,
+			Tags:    []string{"tag1"},
+		},
+	})
+	t.Cleanup(func() {
+		client.Application.Delete(context.Background(), appVersion1.Application.ID)
+	})
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, "2.4.3", appVersion1.Version)
+	testingutils.Assert(t, len(appVersion1.Tags) == 2, "Tags should be present")
+	testingutils.ContainsString(t, "tag1", appVersion1.Tags)
+	testingutils.ContainsString(t, "latest", appVersion1.Tags)
+
+	//
+	// Version 2
+	file2 := CreateTempFile(t, "exampleExtension2.zip")
+	err = downloadFile(uiExtensionURLApp1Version2, file2)
+	testingutils.Ok(t, err)
+
+	appVersion2, _, err := client.UIExtension.CreateExtension(context.Background(), appVersion1.Application, file2.Name(), c8y.UpsertOptions{
+		SkipActivation: false,
+		Version: &c8y.ApplicationVersion{
+			Version: "2.5.0",
+			Tags:    []string{"latest", "tag2"},
+		},
+	})
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, "2.5.0", appVersion2.Version)
+	testingutils.Assert(t, len(appVersion2.Tags) == 2, "Tags should be present")
+	testingutils.ContainsString(t, "tag2", appVersion2.Tags)
+	testingutils.ContainsString(t, "latest", appVersion2.Tags)
+}

--- a/test/c8y_test/uiExtension_test.go
+++ b/test/c8y_test/uiExtension_test.go
@@ -26,9 +26,11 @@ func TestUIExtensionService_CreateExtension(t *testing.T) {
 
 	app1, err := client.UIExtension.NewUIExtensionFromFile(file1.Name())
 	testingutils.Assert(t, app1.Name != "", "Name should not be empty")
+	testingutils.Assert(t, app1.Key != "", "Key should not be empty")
 
 	// Use unique name to avoid name clashes
 	app1.Name = appName
+	app1.Key = appName + "-key"
 	testingutils.Ok(t, err)
 
 	appVersion1, _, err := client.UIExtension.CreateExtension(context.Background(), &app1.Application, file1.Name(), c8y.UpsertOptions{


### PR DESCRIPTION
Add support for management application versions including a higher level UIExtension service (which uses the application versions service).

⚠️ This API is still in a draft state, so expect changes in the future. It is being merged so it can be made accessible to the go-c8y-cli project