### PR TITLE
feat(pagination): support currentPage property

### DIFF
--- a/pkg/c8y/paginationOptions.go
+++ b/pkg/c8y/paginationOptions.go
@@ -10,6 +10,15 @@ type PaginationOptions struct {
 
 	// Include count of elements in the statistics response. Only supported >= 10.13
 	WithTotalElements bool `url:"withTotalElements,omitempty"`
+
+	// Defines the slice of data to be returned, starting with 1. By default, the first page is returned.
+	CurrentPage *int `url:"currentPage,omitempty"`
+}
+
+// Set the current page to return
+func (o *PaginationOptions) SetCurrentPage(v int) *PaginationOptions {
+	o.CurrentPage = &v
+	return o
 }
 
 // NewPaginationOptions returns a pagination options object with a specified pagesize and WithTotalPages set to false


### PR DESCRIPTION
Add `CurrentPage` to the PaginationOptions to allow users to control which page should be returned