### PR TITLE
feat(uiExtension): extend UI manifest file properties

### DIFF
--- a/pkg/c8y/uiExtension.go
+++ b/pkg/c8y/uiExtension.go
@@ -35,12 +35,17 @@ func (m *UIManifest) WithPackage(v string) *UIManifest {
 
 type UIManifestFile struct {
 	Name        string `json:"name,omitempty"`
-	Version     string `json:"version,omitempty"`
 	Key         string `json:"key,omitempty"`
 	ContextPath string `json:"contextPath,omitempty"`
-	Description string `json:"description,omitempty"`
 	Package     string `json:"package,omitempty"`
 	IsPackage   bool   `json:"isPackage,omitempty"`
+	Version     string `json:"version,omitempty"`
+
+	Author                  string              `json:"author"`
+	Description             string              `json:"description,omitempty"`
+	License                 string              `json:"license"`
+	Remotes                 map[string][]string `json:"remotes"`
+	RequiredPlatformVersion string              `json:"requiredPlatformVersion"`
 }
 
 const CumulocityUIManifestFile = "cumulocity.json"

--- a/test/c8y_test/measurement_test.go
+++ b/test/c8y_test/measurement_test.go
@@ -400,6 +400,8 @@ func TestMeasurementService_DeleteMeasurements(t *testing.T) {
 		ValueFragmentType: valueFragmentType,
 	}
 
+	// Wait for measurements to be created
+	time.Sleep(2 * time.Second)
 	measCol1, resp, err := client.Measurement.GetMeasurements(
 		context.Background(),
 		searchOptions,

--- a/test/c8y_test/measurement_test.go
+++ b/test/c8y_test/measurement_test.go
@@ -381,7 +381,7 @@ func TestMeasurementService_DeleteMeasurements(t *testing.T) {
 	testDevice, err := createRandomTestDevice()
 	testingutils.Ok(t, err)
 
-	valueFragmentType := "nx_Type1"
+	valueFragmentType := "nx_Type1_" + testingutils.RandomString(5)
 	createMeasVariable1 := measurementFactory(client, testDevice.ID, valueFragmentType, "Variable1")
 	createMeasVariable2 := measurementFactory(client, testDevice.ID, valueFragmentType, "Variable2")
 
@@ -422,6 +422,7 @@ func TestMeasurementService_DeleteMeasurements(t *testing.T) {
 	// Check that the measurements have been removed
 	// Check by requesting the new collection again as retrieving single measurements
 	// is no longer supported by Cumulocity IoT
+	time.Sleep(2 * time.Second) // give server some time to delete the measurements
 	measColAfter, resp, err := client.Measurement.GetMeasurements(
 		context.Background(),
 		searchOptions,


### PR DESCRIPTION
Extend the support UI Extension manifest properties which are parsed to provide more context about the extension.