### PR TITLE
feat!(microservice): rename agent identity type

### DIFF
--- a/pkg/microservice/configuration.go
+++ b/pkg/microservice/configuration.go
@@ -39,8 +39,8 @@ func (c *Configuration) InitConfiguration() {
 	zap.S().Debug("Setting default configuration properties")
 	config.SetDefault("server.port", "80")
 	config.SetDefault("application.name", "go-microservice")
-	config.SetDefault("agent.identityType", "nx_Microservice")
-	config.SetDefault("agent.operations.pollRate", "@every 1m")
+	config.SetDefault("agent.identityType", "microservice")
+	config.SetDefault("agent.operations.pollRate", "")
 	config.SetDefault("log.file", "application.log")
 
 	// Enable all variables to be defined as (case-sensitive) environment variables in the form of


### PR DESCRIPTION
Rename the default agent identity type for microservices to `microservice`