### PR TITLE
fix(notifications2): prevent concurrent socket writes by using a single send channel

### DIFF
--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -384,8 +384,8 @@ func (c *Notification2Client) Register(pattern string, out chan<- Message) {
 
 func (c *Notification2Client) SendMessageAck(messageIdentifier []byte) error {
 	Logger.Debugf("Sending message ack: %s", messageIdentifier)
-	c.ws.SetWriteDeadline(time.Now().Add(c.ConnectionOptions.GetWriteDuration()))
-	return c.ws.WriteMessage(websocket.TextMessage, messageIdentifier)
+	c.send <- messageIdentifier
+	return nil
 }
 
 func (c *Notification2Client) worker() error {
@@ -437,6 +437,6 @@ func (c *Notification2Client) worker() error {
 // Unsubscribe unsubscribe to a given pattern
 func (c *Notification2Client) Unsubscribe() error {
 	Logger.Info("unsubscribing")
-	c.ws.SetWriteDeadline(time.Now().Add(c.ConnectionOptions.GetWriteDuration()))
-	return c.ws.WriteMessage(websocket.TextMessage, []byte("unsubscribe_subscriber"))
+	c.send <- []byte("unsubscribe_subscriber")
+	return nil
 }


### PR DESCRIPTION
Fix a bug in the notifications2 client where concurrent writes to the websocket were allowed which could cause a panic.

The send channel is now used for all writes.

Resolves  https://github.com/reubenmiller/go-c8y-cli/issues/381