### PR TITLE
fix: don't set basic auth header if username or password is empty

### DIFF
--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -936,8 +936,13 @@ func (c *Client) SetBasicAuthorization(req *http.Request) {
 	} else {
 		headerUsername = c.Username
 	}
-	Logger.Infof("Current username: %s", c.HideSensitiveInformationIfActive(headerUsername))
-	req.SetBasicAuth(headerUsername, c.Password)
+
+	if headerUsername != "" && c.Password != "" {
+		Logger.Infof("Current username: %s", c.HideSensitiveInformationIfActive(headerUsername))
+		req.SetBasicAuth(headerUsername, c.Password)
+	} else {
+		Logger.Debug("Ignoring basic authorization header as either username or password is empty")
+	}
 }
 
 // SetAuthorization sets the configured authorization to the given request. By default it will set the Basic Authorization header


### PR DESCRIPTION
Only set basic auth header if the given username and password are set.