### PR TITLE
fix(ui plugin): only include applications owned by the current tenant

### DIFF
--- a/pkg/c8y/uiExtension.go
+++ b/pkg/c8y/uiExtension.go
@@ -162,8 +162,14 @@ func (s *UIExtensionService) CreateExtension(ctx context.Context, application *A
 		}
 	} else if application.Name != "" {
 		// Lookup via name
-		opts := &ApplicationOptions{}
-		matches, listResp, listErr := s.client.Application.GetApplicationsByName(ctx, application.Name, opts.WithHasVersions(true))
+		hasVersions := true
+		opts := &ApplicationOptions{
+			Name: application.Name,
+			// Only applications that are owned by the current tenant can be managed
+			Owner:       s.client.TenantName,
+			HasVersions: &hasVersions,
+		}
+		matches, listResp, listErr := s.client.Application.GetApplications(ctx, opts)
 		if listErr != nil {
 			return nil, listResp, listErr
 		}


### PR DESCRIPTION
Fix a bug where creating an extension would lookup an application by name, however the API would return any matching application regardless if it was owned by the current tenant or not. This would result in returning an application id that the user could not upload a version to (as only applications owned by the tenant are allowed to do this).