### PR TITLE
feat: add certificate-authority service

### DIFF
--- a/pkg/c8y/certificateAuthority.go
+++ b/pkg/c8y/certificateAuthority.go
@@ -1,0 +1,96 @@
+package c8y
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// CertificateAuthorityService certificate authority service. This features requires the certificate-authority feature toggle to be active.
+type CertificateAuthorityService service
+
+// CertificateAuthorityOptions options to control when creating a certificate authority
+type CertificateAuthorityOptions struct {
+	Status           string
+	AutoRegistration bool
+}
+
+// ResourceCertificateAuthority endpoint
+const ResourceCertificateAuthority = "certificate-authority"
+
+// Create certificate authority
+func (s *CertificateAuthorityService) Create(ctx context.Context, opts CertificateAuthorityOptions) (*Certificate, error) {
+	cert := new(Certificate)
+	resp, err := s.client.SendRequest(ctx, RequestOptions{
+		Method:       http.MethodPost,
+		Path:         ResourceCertificateAuthority,
+		ResponseData: cert,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Don't treat a conflict as an error
+	if resp.StatusCode() == http.StatusConflict {
+		// Get existing certificate
+		existingCert, err := s.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		cert = existingCert
+	}
+
+	if opts.AutoRegistration && !cert.AutoRegistrationEnabled {
+		cert, _, err := s.client.DeviceCertificate.Update(ctx, s.client.GetTenantName(ctx), cert.Fingerprint, Certificate{
+			AutoRegistrationEnabled: opts.AutoRegistration,
+		})
+		return cert, err
+	}
+	return cert, nil
+}
+
+// Delete certificate authority for the current tenant
+func (s *CertificateAuthorityService) Delete(ctx context.Context, fingerprint string) (*Response, error) {
+	if fingerprint == "" {
+		cert, err := s.Get(ctx)
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		fingerprint = cert.Fingerprint
+	}
+
+	return s.client.DeviceCertificate.Delete(ctx, s.client.GetTenantName(ctx), fingerprint)
+}
+
+// Get certificate authority for the current tenant
+func (s *CertificateAuthorityService) Get(ctx context.Context) (*Certificate, error) {
+	items, _, err := s.client.DeviceCertificate.GetCertificates(ctx, s.client.GetTenantName(ctx), &DeviceCertificateCollectionOptions{
+		PaginationOptions: *NewPaginationOptions(2000),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range items.Certificates {
+		if item.TenantCertificateAuthority {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// Update certificate authority for the current tenant
+// Leave the fingerprint blank if you want to automatically lookup the certificate authority
+func (s *CertificateAuthorityService) Update(ctx context.Context, fingerprint string, opts *Certificate) (*Certificate, *Response, error) {
+	if fingerprint == "" {
+		cert, err := s.Get(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		fingerprint = cert.Fingerprint
+	}
+	return s.client.DeviceCertificate.Update(ctx, s.client.GetTenantName(ctx), fingerprint, opts)
+}

--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -128,29 +128,30 @@ type Client struct {
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
 	// Services used for talking to different parts of the Cumulocity API.
-	Context             *ContextService
-	Alarm               *AlarmService
-	Audit               *AuditService
-	DeviceCredentials   *DeviceCredentialsService
-	Measurement         *MeasurementService
-	Operation           *OperationService
-	Tenant              *TenantService
-	Event               *EventService
-	Inventory           *InventoryService
-	Application         *ApplicationService
-	UIExtension         *UIExtensionService
-	ApplicationVersions *ApplicationVersionsService
-	Identity            *IdentityService
-	Microservice        *MicroserviceService
-	Notification2       *Notification2Service
-	RemoteAccess        *RemoteAccessService
-	Retention           *RetentionRuleService
-	TenantOptions       *TenantOptionsService
-	Software            *InventorySoftwareService
-	Firmware            *InventoryFirmwareService
-	User                *UserService
-	DeviceCertificate   *DeviceCertificateService
-	Features            *FeaturesService
+	Context              *ContextService
+	Alarm                *AlarmService
+	Audit                *AuditService
+	DeviceCredentials    *DeviceCredentialsService
+	Measurement          *MeasurementService
+	Operation            *OperationService
+	Tenant               *TenantService
+	Event                *EventService
+	Inventory            *InventoryService
+	Application          *ApplicationService
+	UIExtension          *UIExtensionService
+	ApplicationVersions  *ApplicationVersionsService
+	Identity             *IdentityService
+	Microservice         *MicroserviceService
+	Notification2        *Notification2Service
+	RemoteAccess         *RemoteAccessService
+	Retention            *RetentionRuleService
+	TenantOptions        *TenantOptionsService
+	Software             *InventorySoftwareService
+	Firmware             *InventoryFirmwareService
+	User                 *UserService
+	DeviceCertificate    *DeviceCertificateService
+	CertificateAuthority *CertificateAuthorityService
+	Features             *FeaturesService
 }
 
 const (
@@ -383,6 +384,7 @@ func NewClient(httpClient *http.Client, baseURL string, tenant string, username 
 	c.Firmware = (*InventoryFirmwareService)(&c.common)
 	c.User = (*UserService)(&c.common)
 	c.Features = (*FeaturesService)(&c.common)
+	c.CertificateAuthority = (*CertificateAuthorityService)(&c.common)
 	return c
 }
 

--- a/pkg/c8y/deviceCertificate.go
+++ b/pkg/c8y/deviceCertificate.go
@@ -6,6 +6,11 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+const (
+	CertificateStatusEnabled  = "ENABLED"
+	CertificateStatusDisabled = "DISABLED"
+)
+
 // DeviceCertificateService interacts with the trusted device certificates in the platform
 type DeviceCertificateService service
 
@@ -26,19 +31,20 @@ type DeviceCertificateCollection struct {
 
 // Certificate properties
 type Certificate struct {
-	AlgorithmName           string `json:"algorithmName"`
-	CertInPemFormat         string `json:"certInPemFormat"`
-	Fingerprint             string `json:"fingerprint"`
-	Issuer                  string `json:"issuer"`
-	Name                    string `json:"name"`
-	NotAfter                string `json:"notAfter"`
-	NotBefore               string `json:"notBefore"`
-	Self                    string `json:"self"`
-	SerialNumber            string `json:"serialNumber"`
-	Status                  string `json:"status"`
-	Subject                 string `json:"subject"`
-	AutoRegistrationEnabled bool   `json:"autoRegistrationEnabled"`
-	Version                 int    `json:"version"`
+	AlgorithmName              string `json:"algorithmName,omitempty"`
+	CertInPemFormat            string `json:"certInPemFormat,omitempty"`
+	Fingerprint                string `json:"fingerprint,omitempty"`
+	Issuer                     string `json:"issuer,omitempty"`
+	Name                       string `json:"name,omitempty"`
+	NotAfter                   string `json:"notAfter,omitempty"`
+	NotBefore                  string `json:"notBefore,omitempty"`
+	Self                       string `json:"self,omitempty"`
+	SerialNumber               string `json:"serialNumber,omitempty"`
+	Status                     string `json:"status,omitempty"`
+	Subject                    string `json:"subject,omitempty"`
+	AutoRegistrationEnabled    bool   `json:"autoRegistrationEnabled,omitempty"`
+	TenantCertificateAuthority bool   `json:"tenantCertificateAuthority,omitempty"`
+	Version                    int    `json:"version,omitempty"`
 }
 
 // GetCertificates returns collection of certificates

--- a/test/c8y_test/certificateAuthority_test.go
+++ b/test/c8y_test/certificateAuthority_test.go
@@ -1,0 +1,45 @@
+package c8y_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/reubenmiller/go-c8y/internal/pkg/testingutils"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+)
+
+func TestCertificateAuthority_get(t *testing.T) {
+	client := createTestClient()
+
+	ctx := context.Background()
+
+	// Delete (setup)
+	_, setupErr := client.CertificateAuthority.Delete(ctx, "")
+	testingutils.Ok(t, setupErr)
+
+	cert, err := client.CertificateAuthority.Create(ctx, c8y.CertificateAuthorityOptions{
+		AutoRegistration: true,
+	})
+	testingutils.Ok(t, err)
+	testingutils.Assert(t, cert.Fingerprint != "", "fingerprint should not be empty")
+
+	// Get
+	cert2, err := client.CertificateAuthority.Get(ctx)
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, cert.Fingerprint, cert2.Fingerprint)
+
+	// Update
+	cert3, resp, err := client.CertificateAuthority.Update(ctx, cert2.Fingerprint, &c8y.Certificate{
+		Status:                  c8y.CertificateStatusDisabled,
+		AutoRegistrationEnabled: false,
+	})
+	testingutils.Ok(t, err)
+	testingutils.Equals(t, resp.StatusCode(), http.StatusOK)
+	testingutils.Equals(t, cert.Fingerprint, cert3.Fingerprint)
+
+	// Delete
+	resp, deleteErr := client.CertificateAuthority.Delete(ctx, cert.Fingerprint)
+	testingutils.Ok(t, deleteErr)
+	testingutils.Equals(t, resp.StatusCode(), http.StatusNoContent)
+}


### PR DESCRIPTION
Add certificate-authority service to manage the upcoming certificate-authority feature (currently on available on demand via the PRIVATE_PREVIEW).