### PR TITLE
fix(certificates): allow setting the auto registration to false

### DIFF
--- a/pkg/c8y/certificateAuthority.go
+++ b/pkg/c8y/certificateAuthority.go
@@ -48,9 +48,9 @@ func (s *CertificateAuthorityService) Create(ctx context.Context, opts Certifica
 		return nil, nil
 	}
 
-	if opts.AutoRegistration != cert.AutoRegistrationEnabled || (opts.Status != "" && opts.Status != cert.Status) {
+	if opts.AutoRegistration != cert.IsAutoRegistrationEnabled() || (opts.Status != "" && opts.Status != cert.Status) {
 		cert, _, err := s.client.DeviceCertificate.Update(ctx, s.client.GetTenantName(ctx), cert.Fingerprint, Certificate{
-			AutoRegistrationEnabled: opts.AutoRegistration,
+			AutoRegistrationEnabled: &opts.AutoRegistration,
 			Status:                  opts.Status,
 		})
 		return cert, err

--- a/pkg/c8y/deviceCertificate.go
+++ b/pkg/c8y/deviceCertificate.go
@@ -29,6 +29,10 @@ type DeviceCertificateCollection struct {
 	Items []gjson.Result `json:"-"`
 }
 
+func NewCertificate() *Certificate {
+	return &Certificate{}
+}
+
 // Certificate properties
 type Certificate struct {
 	AlgorithmName              string `json:"algorithmName,omitempty"`
@@ -42,9 +46,29 @@ type Certificate struct {
 	SerialNumber               string `json:"serialNumber,omitempty"`
 	Status                     string `json:"status,omitempty"`
 	Subject                    string `json:"subject,omitempty"`
-	AutoRegistrationEnabled    bool   `json:"autoRegistrationEnabled,omitempty"`
+	AutoRegistrationEnabled    *bool  `json:"autoRegistrationEnabled,omitempty"`
 	TenantCertificateAuthority bool   `json:"tenantCertificateAuthority,omitempty"`
 	Version                    int    `json:"version,omitempty"`
+}
+
+// Check if auto registration is enabled or not
+func (c *Certificate) IsAutoRegistrationEnabled() bool {
+	if c.AutoRegistrationEnabled == nil {
+		return false
+	}
+	return *c.AutoRegistrationEnabled
+}
+
+// Set the certificate status, ENABLED or DISABLED
+func (c *Certificate) WithStatus(v string) *Certificate {
+	c.Status = v
+	return c
+}
+
+// Set the auto registration status
+func (c *Certificate) WithAutoRegistration(enabled bool) *Certificate {
+	c.AutoRegistrationEnabled = &enabled
+	return c
 }
 
 // GetCertificates returns collection of certificates

--- a/test/c8y_test/certificateAuthority_test.go
+++ b/test/c8y_test/certificateAuthority_test.go
@@ -41,16 +41,22 @@ func TestCertificateAuthority_get(t *testing.T) {
 	dryRunContext := c8y.WithCommonOptionsContext(ctx, c8y.CommonOptions{
 		DryRun: true,
 	})
-	_, _, dryRunErr := client.CertificateAuthority.Update(dryRunContext, "", &c8y.Certificate{
-		AutoRegistrationEnabled: true,
-	})
+	_, _, dryRunErr := client.CertificateAuthority.Update(
+		dryRunContext,
+		"",
+		c8y.NewCertificate().
+			WithAutoRegistration(true),
+	)
 	testingutils.Ok(t, dryRunErr)
 
 	// Update
-	cert3, resp, err := client.CertificateAuthority.Update(ctx, cert2.Fingerprint, &c8y.Certificate{
-		Status:                  c8y.CertificateStatusDisabled,
-		AutoRegistrationEnabled: false,
-	})
+	cert3, resp, err := client.CertificateAuthority.Update(
+		ctx,
+		cert2.Fingerprint,
+		c8y.NewCertificate().
+			WithAutoRegistration(false).
+			WithStatus(c8y.CertificateStatusDisabled),
+	)
 	testingutils.Ok(t, err)
 	testingutils.Equals(t, resp.StatusCode(), http.StatusOK)
 	testingutils.Equals(t, cert.Fingerprint, cert3.Fingerprint)


### PR DESCRIPTION
Fix a bug where the API would ignore the auto registration value when set to false.