### PR TITLE
fix: microservice service user lookup improvements

### DIFF
--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -1214,7 +1214,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}, middl
 
 	// Check if an authorization key is provided in the context, if so then override the c8y authentication
 	if authToken := ctx.Value(GetContextAuthTokenKey()); authToken != nil {
-		Logger.Infof("Overriding basic auth provided in the context")
+		Logger.Infof("Using authorization provided in the context")
 		req.Header.Set("Authorization", authToken.(string))
 	}
 

--- a/pkg/microservice/microservice.go
+++ b/pkg/microservice/microservice.go
@@ -249,6 +249,19 @@ func (m *Microservice) WithServiceUser(tenant ...string) context.Context {
 	return m.Client.Context.ServiceUserContext(tenant[0], true)
 }
 
+// WithServiceUserCache returns the default service user (i.e. the first tenant), but it
+// allows the user to control whether the list of service users should be updated or not
+// Can be used when using a PER_TENANT microservice as there will only ever be one tenant
+func (m *Microservice) WithServiceUserCache(skipUpdateServiceUsers bool, tenant ...string) context.Context {
+	if len(tenant) > 1 {
+		panic(fmt.Errorf("context only accepts 1 tenant"))
+	}
+	if len(tenant) == 0 {
+		return m.Client.Context.ServiceUserContext("", skipUpdateServiceUsers)
+	}
+	return m.Client.Context.ServiceUserContext(tenant[0], skipUpdateServiceUsers)
+}
+
 // WithBootstrapUserCredentials returns the application credentials
 func (m *Microservice) WithBootstrapUserCredentials() c8y.ServiceUser {
 	return c8y.ServiceUser{


### PR DESCRIPTION
Some improvements for the service user lookup when used in a multi-tenant microservice.

* New function `WithServiceUserCache`, to allow users to control whether the servier user list should be updated or not before trying to fetch the given service user
* Automatically update the service user cache when the user is not found