### PR TITLE
feat: add gjson array accessors for managed object references

### DIFF
--- a/examples/child-reference/main.go
+++ b/examples/child-reference/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+)
+
+func main() {
+	client := c8y.NewClientFromEnvironment(nil, false)
+
+	mor, resp, _ := client.Inventory.GetChildAdditions(context.Background(), "25636204",
+		&c8y.ManagedObjectOptions{
+			Query: "type eq myTest",
+		})
+
+	// Option 1: Using the Items which is a gjson array (this was only added in v0.28.0)
+	fmt.Println("\n\nOption 1: Accessing data from the gjson array .Items")
+	for i, mor := range mor.Items {
+		fmt.Printf("\nChild %d\n", i)
+		fmt.Printf("managedObject.id: %s\n", mor.Get("managedObject.id").String())
+		if helloValue := mor.Get("managedObject.hello"); helloValue.Exists() {
+			fmt.Printf("managedObject.hello: %s\n", helloValue)
+		} else {
+			fmt.Printf("managedObject.hello: <unset>\n")
+		}
+	}
+
+	// Option 2: Using resp object directly to handle your own serialization
+	fmt.Println("\n\nOption 2: Accessing data from the raw response using gjson")
+	references := resp.JSON("references").Array()
+	for i, mor := range references {
+		fmt.Printf("\nChild %d\n", i)
+		fmt.Printf("managedObject.id: %s\n", mor.Get("managedObject.id").String())
+		if helloValue := mor.Get("managedObject.hello"); helloValue.Exists() {
+			fmt.Printf("managedObject.hello: %s\n", helloValue)
+		} else {
+			fmt.Printf("managedObject.hello: <unset>\n")
+		}
+	}
+}

--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -845,6 +845,21 @@ func (c *Client) SetJSONItems(resp *Response, v interface{}) error {
 	case *UserCollection:
 		t.Items = resp.JSON("users").Array()
 
+	// Managed object references
+	case *ChildDevices:
+		t.Items = resp.JSON("references").Array()
+	case *ParentDevices:
+		t.Items = resp.JSON("references").Array()
+	case *AdditionParents:
+		t.Items = resp.JSON("references").Array()
+	case *AssetParents:
+		t.Items = resp.JSON("references").Array()
+	case *ChildAssets:
+		t.Items = resp.JSON("references").Array()
+	case *ChildAdditions:
+		t.Items = resp.JSON("references").Array()
+	case *ManagedObjectReferencesCollection:
+		t.Items = resp.JSON("references").Array()
 	}
 
 	return nil

--- a/pkg/c8y/inventory.go
+++ b/pkg/c8y/inventory.go
@@ -158,44 +158,61 @@ type Kpi struct {
 	Fragment string `json:"fragment"`
 }
 
-// ChildDevices todo
+// ChildDevices managed object references
 type ChildDevices struct {
 	Self       string                   `json:"self"`
 	References []ManagedObjectReference `json:"references"`
+
+	Items []gjson.Result `json:"-"`
 }
 
-// ParentDevices todo
+// ParentDevices managed object references
 type ParentDevices struct {
 	Self       string                   `json:"self"`
 	References []ManagedObjectReference `json:"references"`
+
+	Items []gjson.Result `json:"-"`
 }
 
+// AdditionParents managed object references
 type AdditionParents struct {
 	Self       string                   `json:"self"`
 	References []ManagedObjectReference `json:"references"`
+
+	Items []gjson.Result `json:"-"`
 }
 
+// AssetParents managed object references
 type AssetParents struct {
 	Self       string                   `json:"self"`
 	References []ManagedObjectReference `json:"references"`
+
+	Items []gjson.Result `json:"-"`
 }
 
+// ChildAssets managed object references
 type ChildAssets struct {
 	Self       string                   `json:"self"`
 	References []ManagedObjectReference `json:"references"`
+
+	Items []gjson.Result `json:"-"`
 }
 
+// ChildAdditions managed object references
 type ChildAdditions struct {
 	Self       string                   `json:"self"`
 	References []ManagedObjectReference `json:"references"`
+
+	Items []gjson.Result `json:"-"`
 }
 
-// ManagedObjectCollection todo
+// ManagedObjectCollection collection of managed objects
 type ManagedObjectCollection struct {
 	*BaseResponse
 
 	ManagedObjects []ManagedObject `json:"managedObjects"`
-	Items          []gjson.Result
+
+	Items []gjson.Result `json:"-"`
 }
 
 // SupportedSeries is a list of the supported series in the format of <fragment>.<series>
@@ -212,6 +229,8 @@ type SupportedMeasurements struct {
 type ManagedObjectReferencesCollection struct {
 	*BaseResponse
 	References []ManagedObjectReference `json:"references"`
+
+	Items []gjson.Result `json:"-"`
 }
 
 // ManagedObjectReference Managed object reference

--- a/pkg/c8y/inventory.go
+++ b/pkg/c8y/inventory.go
@@ -246,12 +246,6 @@ func (s *InventoryService) GetDevices(ctx context.Context, paging *PaginationOpt
 	return data, resp, err
 }
 
-// All todo
-func (s *ManagedObjectCollection) All() error {
-	// TODO: Get All results
-	return nil
-}
-
 // GetManagedObject returns a managed object by its id
 func (s *InventoryService) GetManagedObject(ctx context.Context, ID string, opt *ManagedObjectOptions) (*ManagedObject, *Response, error) {
 	data := new(ManagedObject)


### PR DESCRIPTION
The managed object references structs were missing the generic `.Items` [gjson](https://github.com/tidwall/gjson) accessor to make it more convenient to access custom properties of each item of the array in the response.