### PR TITLE
feat: allow users to set CSR properties and add deviceenrollment helper

### DIFF
--- a/examples/device-enrollment/main.go
+++ b/examples/device-enrollment/main.go
@@ -88,7 +88,7 @@ func main() {
 	fmt.Fprintf(os.Stderr, "\n📣 Starting device enrollment: externalID=%s\n", deviceID)
 
 	// Create CSR
-	csr, err := certutil.CreateCertificateSigningRequest(deviceID, key)
+	csr, err := client.DeviceEnrollment.CreateCertificateSigningRequest(deviceID, key)
 	stopOnError(err)
 
 	ctx := c8y.NewSilentLoggerContext(context.Background())

--- a/pkg/c8y/enrollment.go
+++ b/pkg/c8y/enrollment.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	_ "embed"
 	"encoding/base64"
 	"errors"
@@ -61,6 +62,22 @@ func (s *DeviceEnrollmentService) Enroll(ctx context.Context, externalID string,
 	}
 
 	return s.parsePKCS7Response(resp)
+}
+
+// CreateCertificateSigningRequest creates a certificate signing request using the given external id and private key
+// The subject of the certificate will be set to the external id
+// Sensible defaults are used to set the Organization and OrganizationalUnit. If you want your own
+// custom values, then use certutil.CreateCertificateSigningRequest directly
+func (s *DeviceEnrollmentService) CreateCertificateSigningRequest(externalId string, key any) (*x509.CertificateRequest, error) {
+	return certutil.CreateCertificateSigningRequest(pkix.Name{
+		CommonName: externalId,
+		Organization: []string{
+			"Cumulocity",
+		},
+		OrganizationalUnit: []string{
+			"Device",
+		},
+	}, key)
 }
 
 // Re enrollment options

--- a/pkg/certutil/certutil.go
+++ b/pkg/certutil/certutil.go
@@ -392,8 +392,8 @@ func MarshalCertificateToPEM(derBytes []byte) []byte {
 }
 
 // CreateCertificateSigningRequest creates a certificate signing request
-func CreateCertificateSigningRequest(id string, key any) (*x509.CertificateRequest, error) {
-	template := x509.CertificateRequest{Subject: pkix.Name{CommonName: id}}
+func CreateCertificateSigningRequest(subject pkix.Name, key any) (*x509.CertificateRequest, error) {
+	template := x509.CertificateRequest{Subject: subject}
 	reqBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, key)
 	if err != nil {
 		return nil, err

--- a/test/c8y_test/enroll_test.go
+++ b/test/c8y_test/enroll_test.go
@@ -38,7 +38,7 @@ func TestSimpleEnrollment_PollEnroll(t *testing.T) {
 	testingutils.Ok(t, err)
 
 	// Enroll
-	csr, err := certutil.CreateCertificateSigningRequest(deviceID, key)
+	csr, err := client.DeviceEnrollment.CreateCertificateSigningRequest(deviceID, key)
 	testingutils.Ok(t, err)
 	testingutils.Equals(t, deviceID, csr.Subject.CommonName)
 
@@ -115,7 +115,7 @@ func TestSimpleEnrollment_Register(t *testing.T) {
 	testingutils.Ok(t, err)
 
 	// Enroll
-	csr, err := certutil.CreateCertificateSigningRequest(deviceID, key)
+	csr, err := client.DeviceEnrollment.CreateCertificateSigningRequest(deviceID, key)
 	testingutils.Ok(t, err)
 	testingutils.Equals(t, deviceID, csr.Subject.CommonName)
 
@@ -135,7 +135,7 @@ func TestSimpleEnrollment_Register(t *testing.T) {
 	testingutils.Assert(t, token.AccessToken != "", "Token should not be empty")
 
 	// Re-enroll
-	secondCSR, err := certutil.CreateCertificateSigningRequest(deviceID, key)
+	secondCSR, err := client.DeviceEnrollment.CreateCertificateSigningRequest(deviceID, key)
 	testingutils.Ok(t, err)
 	secondCert, resp, err := client.DeviceEnrollment.ReEnroll(context.Background(), c8y.ReEnrollOptions{
 		Token: token.AccessToken,


### PR DESCRIPTION
Allow users to control the CSR properties when using the certutil, and add a new device enrollment csr method to assist in creating a csr with sensible defaults