### PR TITLE
feat: add dry run marker to response

### DIFF
--- a/pkg/c8y/enrollment.go
+++ b/pkg/c8y/enrollment.go
@@ -61,6 +61,10 @@ func (s *DeviceEnrollmentService) Enroll(ctx context.Context, externalID string,
 		return nil, resp, err
 	}
 
+	if resp.IsDryRun() {
+		return nil, resp, nil
+	}
+
 	return s.parsePKCS7Response(resp)
 }
 
@@ -118,6 +122,10 @@ func (s *DeviceEnrollmentService) ReEnroll(ctx context.Context, opts ReEnrollOpt
 
 	if err != nil {
 		return nil, resp, err
+	}
+
+	if resp.IsDryRun() {
+		return nil, resp, nil
 	}
 
 	return s.parsePKCS7Response(resp)

--- a/pkg/c8y/response.go
+++ b/pkg/c8y/response.go
@@ -29,6 +29,12 @@ type Response struct {
 	size       int64
 	receivedAt time.Time
 	duration   time.Duration
+	dryRun     bool
+}
+
+// IsDryRun return if the response is from a dry run
+func (r *Response) IsDryRun() bool {
+	return r.dryRun
 }
 
 func (r *Response) Duration() time.Duration {


### PR DESCRIPTION
Mark responses with the value of the dry run so that it is easier to check if follow up actions should be done or not