### PR TITLE
feat: add client option to control logging of sensitive info or not

### DIFF
--- a/pkg/c8y/certificateAuthority.go
+++ b/pkg/c8y/certificateAuthority.go
@@ -44,6 +44,10 @@ func (s *CertificateAuthorityService) Create(ctx context.Context, opts Certifica
 	}
 
 	if resp == nil {
+		return nil, nil
+	}
+
+	if resp.IsDryRun() {
 		// Dry run
 		return nil, nil
 	}


### PR DESCRIPTION
Allows the logging of sensitive information to be controlled by a client option instead of an env variable