### PR TITLE
feat: add oauth device flow support

### DIFF
--- a/examples/device-flow/main.go
+++ b/examples/device-flow/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/reubenmiller/go-c8y/pkg/oauth/api"
+)
+
+func main() {
+	c8y.SilenceLogger()
+
+	// Create the client from the following environment variables
+	client := c8y.NewClientFromOptions(nil, c8y.ClientOptions{
+		BaseURL:  os.Getenv("C8Y_HOST"),
+		Realtime: false,
+	})
+
+	loginOption, found, err := client.Tenant.HasExternalAuthProvider(context.Background())
+	if err != nil {
+		log.Fatalf("Could not get Cumulocity login options. %s", err)
+	}
+	if !found {
+		log.Fatalf("Cumulocity instance does not have an external OAUTH2 provider configured")
+	}
+
+	// Request token using device flow
+	fmt.Fprintf(os.Stderr, "🏄 Signing in using OAuth2 device flow\n\n")
+	_, err = client.Tenant.AuthorizeWithDeviceFlow(context.Background(), loginOption.InitRequest, api.AuthEndpoints{
+		DeviceAuthorizationURL: "/oauth/device/code",
+		TokenURL:               "/oauth/token",
+	})
+	if err != nil {
+		log.Fatalf("Failed to get access token. %s", err)
+	}
+
+	// Verify
+	// client.SetToken(token.Token)
+	// client.AuthorizationMethod = c8y.AuthMethodOAuth2
+
+	fmt.Fprintf(os.Stderr, "🔍 Checking if the token can be used to make API calls\n")
+	_, _, err = client.Alarm.GetAlarms(
+		context.Background(),
+		&c8y.AlarmCollectionOptions{
+			Severity: c8y.AlarmSeverityMajor,
+		},
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "🚫 API call failed. %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "✅ API call was successful using the token from oAuth2\n")
+	os.Exit(0)
+}

--- a/pkg/c8y/client.go
+++ b/pkg/c8y/client.go
@@ -212,6 +212,9 @@ const (
 	// AuthMethodOAuth2Internal OAuth2 internal mode
 	AuthMethodOAuth2Internal = "OAUTH2_INTERNAL"
 
+	// AuthMethodOAuth2 OAuth2 external provider
+	AuthMethodOAuth2 = "OAUTH2"
+
 	// AuthMethodBasic Basic authentication
 	AuthMethodBasic = "BASIC"
 
@@ -234,6 +237,8 @@ func ParseAuthMethod(v string) (string, error) {
 		return AuthMethodNone, nil
 	case AuthMethodOAuth2Internal:
 		return AuthMethodOAuth2Internal, nil
+	case AuthMethodOAuth2:
+		return AuthMethodOAuth2, nil
 	default:
 		return "", ErrInvalidAuthMethod
 	}
@@ -1129,7 +1134,7 @@ func (c *Client) SetBasicAuthorization(req *http.Request) {
 // SetAuthorization sets the configured authorization to the given request. By default it will set the Basic Authorization header
 func (c *Client) SetAuthorization(req *http.Request) {
 	switch c.AuthorizationMethod {
-	case AuthMethodOAuth2Internal:
+	case AuthMethodOAuth2Internal, AuthMethodOAuth2:
 		c.SetBearerAuthorization(req)
 		c.addOAuth2ToRequest(req)
 	case AuthMethodNone:

--- a/pkg/oauth/api/access_token.go
+++ b/pkg/oauth/api/access_token.go
@@ -1,0 +1,27 @@
+package api
+
+// AccessToken is an OAuth access token.
+type AccessToken struct {
+	// The token value, typically a 40-character random string.
+	Token string
+	// The refresh token value, associated with the access token.
+	RefreshToken string
+	// The token type, e.g. "bearer".
+	Type string
+	// Space-separated list of OAuth scopes that this token grants.
+	Scope string
+}
+
+// AccessToken extracts the access token information from a server response.
+func (f FormResponse) AccessToken() (*AccessToken, error) {
+	if accessToken := f.Get("access_token"); accessToken != "" {
+		return &AccessToken{
+			Token:        accessToken,
+			RefreshToken: f.Get("refresh_token"),
+			Type:         f.Get("token_type"),
+			Scope:        f.Get("scope"),
+		}, nil
+	}
+
+	return nil, f.Err()
+}

--- a/pkg/oauth/api/access_token_test.go
+++ b/pkg/oauth/api/access_token_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestFormResponse_AccessToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		response FormResponse
+		want     *AccessToken
+		wantErr  *Error
+	}{
+		{
+			name: "with token",
+			response: FormResponse{
+				values: url.Values{
+					"access_token": []string{"aToken"},
+					"token_type":   []string{"bearer"},
+					"scope":        []string{"repo gist"},
+				},
+			},
+			want: &AccessToken{
+				Token:        "aToken",
+				RefreshToken: "",
+				Type:         "bearer",
+				Scope:        "repo gist",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "with refresh token",
+			response: FormResponse{
+				values: url.Values{
+					"access_token":  []string{"aToken"},
+					"refresh_token": []string{"aRefreshToken"},
+					"token_type":    []string{"bearer"},
+					"scope":         []string{"repo gist"},
+				},
+			},
+			want: &AccessToken{
+				Token:        "aToken",
+				RefreshToken: "aRefreshToken",
+				Type:         "bearer",
+				Scope:        "repo gist",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "no token",
+			response: FormResponse{
+				StatusCode: 200,
+				values: url.Values{
+					"error": []string{"access_denied"},
+				},
+			},
+			want: nil,
+			wantErr: &Error{
+				Code:         "access_denied",
+				ResponseCode: 200,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.response.AccessToken()
+			if err != nil {
+				apiError := err.(*Error)
+				if !reflect.DeepEqual(apiError, tt.wantErr) {
+					t.Fatalf("error %v, want %v", apiError, tt.wantErr)
+				}
+			} else if tt.wantErr != nil {
+				t.Fatalf("want error %v, got nil", tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FormResponse.AccessToken() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/oauth/api/endpoint.go
+++ b/pkg/oauth/api/endpoint.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// AuthorizationRequest OAuth2 authorization request data
+type AuthorizationRequest struct {
+	// The token value, typically a 40-character random string.
+	ClientID string
+
+	// Audience
+	Audience string
+
+	// Scopes
+	Scopes []string
+
+	// The refresh token value, associated with the access token.
+	URL *url.URL
+}
+
+// AuthEndpoints OAuth2 endpoints used to get retrieve the device code and access token
+type AuthEndpoints struct {
+	// Device Authorization URL e.g. /oauth/device/code
+	DeviceAuthorizationURL string
+
+	// Token Authorization URL, e.g. /oauth/token
+	TokenURL string
+}
+
+// GetEndpointUrl get the full url related to a given oauth endpoint
+func GetEndpointUrl(endpoint *AuthorizationRequest, u string) string {
+	if endpoint == nil {
+		return u
+	}
+	return fmt.Sprintf("%s://%s/%s", endpoint.URL.Scheme, endpoint.URL.Host, strings.TrimLeft(u, "/"))
+}

--- a/pkg/oauth/api/form.go
+++ b/pkg/oauth/api/form.go
@@ -1,0 +1,114 @@
+// Package api implements request and response parsing logic shared between different OAuth strategies.
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type httpClient interface {
+	PostForm(string, url.Values) (*http.Response, error)
+}
+
+// FormResponse is the parsed "www-form-urlencoded" response from the server.
+type FormResponse struct {
+	StatusCode int
+
+	requestURI string
+	values     url.Values
+}
+
+// Get the response value named k.
+func (f FormResponse) Get(k string) string {
+	return f.values.Get(k)
+}
+
+// Err returns an Error object extracted from the response.
+func (f FormResponse) Err() error {
+	return &Error{
+		RequestURI:   f.requestURI,
+		ResponseCode: f.StatusCode,
+		Code:         f.Get("error"),
+		message:      f.Get("error_description"),
+	}
+}
+
+// Error is the result of an unexpected HTTP response from the server.
+type Error struct {
+	Code         string
+	ResponseCode int
+	RequestURI   string
+
+	message string
+}
+
+func (e Error) Error() string {
+	if e.message != "" {
+		return fmt.Sprintf("%s (%s)", e.message, e.Code)
+	}
+	if e.Code != "" {
+		return e.Code
+	}
+	return fmt.Sprintf("HTTP %d", e.ResponseCode)
+}
+
+// PostForm makes an POST request by serializing input parameters as a form and parsing the response
+// of the same type.
+func PostForm(c httpClient, u string, params url.Values) (*FormResponse, error) {
+	resp, err := c.PostForm(u, params)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	r := &FormResponse{
+		StatusCode: resp.StatusCode,
+		requestURI: u,
+	}
+
+	mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	switch mediaType {
+	case "application/x-www-form-urlencoded":
+		var bb []byte
+		bb, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return r, err
+		}
+
+		r.values, err = url.ParseQuery(string(bb))
+		if err != nil {
+			return r, err
+		}
+	case "application/json":
+		var values map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&values); err != nil {
+			return r, err
+		}
+
+		r.values = make(url.Values)
+		for key, value := range values {
+			switch v := value.(type) {
+			case string:
+				r.values.Set(key, v)
+			case int64:
+				r.values.Set(key, strconv.FormatInt(v, 10))
+			case float64:
+				r.values.Set(key, strconv.FormatFloat(v, 'f', -1, 64))
+			}
+		}
+	default:
+		_, err = io.Copy(io.Discard, resp.Body)
+		if err != nil {
+			return r, err
+		}
+	}
+
+	return r, nil
+}

--- a/pkg/oauth/api/form_test.go
+++ b/pkg/oauth/api/form_test.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestFormResponse_Get(t *testing.T) {
+	tests := []struct {
+		name     string
+		response FormResponse
+		key      string
+		want     string
+	}{
+		{
+			name:     "blank",
+			response: FormResponse{},
+			key:      "access_token",
+			want:     "",
+		},
+		{
+			name: "with value",
+			response: FormResponse{
+				values: url.Values{
+					"access_token": []string{"aToken"},
+				},
+			},
+			key:  "access_token",
+			want: "aToken",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.response.Get(tt.key); got != tt.want {
+				t.Errorf("FormResponse.Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormResponse_Err(t *testing.T) {
+	tests := []struct {
+		name     string
+		response FormResponse
+		wantErr  Error
+		errorMsg string
+	}{
+		{
+			name:     "blank",
+			response: FormResponse{},
+			wantErr:  Error{},
+			errorMsg: "HTTP 0",
+		},
+		{
+			name: "with values",
+			response: FormResponse{
+				StatusCode: 422,
+				requestURI: "http://example.com/path",
+				values: url.Values{
+					"error":             []string{"try_again"},
+					"error_description": []string{"maybe it works later"},
+				},
+			},
+			wantErr: Error{
+				Code:         "try_again",
+				ResponseCode: 422,
+				RequestURI:   "http://example.com/path",
+			},
+			errorMsg: "maybe it works later (try_again)",
+		},
+		{
+			name: "no values",
+			response: FormResponse{
+				StatusCode: 422,
+				requestURI: "http://example.com/path",
+			},
+			wantErr: Error{
+				Code:         "",
+				ResponseCode: 422,
+				RequestURI:   "http://example.com/path",
+			},
+			errorMsg: "HTTP 422",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.response.Err()
+			if err == nil {
+				t.Fatalf("FormResponse.Err() = %v, want %v", nil, tt.wantErr)
+			}
+			apiError := err.(*Error)
+			if apiError.Code != tt.wantErr.Code {
+				t.Errorf("Error.Code = %v, want %v", apiError.Code, tt.wantErr.Code)
+			}
+			if apiError.ResponseCode != tt.wantErr.ResponseCode {
+				t.Errorf("Error.ResponseCode = %v, want %v", apiError.ResponseCode, tt.wantErr.ResponseCode)
+			}
+			if apiError.RequestURI != tt.wantErr.RequestURI {
+				t.Errorf("Error.RequestURI = %v, want %v", apiError.RequestURI, tt.wantErr.RequestURI)
+			}
+			if apiError.Error() != tt.errorMsg {
+				t.Errorf("Error.Error() = %q, want %q", apiError.Error(), tt.errorMsg)
+			}
+		})
+	}
+}
+
+type apiClient struct {
+	status      int
+	body        string
+	contentType string
+
+	postCount int
+}
+
+func (c *apiClient) PostForm(u string, params url.Values) (*http.Response, error) {
+	c.postCount++
+	return &http.Response{
+		Body: io.NopCloser(bytes.NewBufferString(c.body)),
+		Header: http.Header{
+			"Content-Type": {c.contentType},
+		},
+		StatusCode: c.status,
+	}, nil
+}
+
+func TestPostForm(t *testing.T) {
+	type args struct {
+		url    string
+		params url.Values
+	}
+	tests := []struct {
+		name    string
+		args    args
+		http    apiClient
+		want    *FormResponse
+		wantErr bool
+	}{
+		{
+			name: "success urlencoded",
+			args: args{
+				url: "https://example.com/oauth",
+			},
+			http: apiClient{
+				body:        "access_token=123abc&scopes=repo%20gist",
+				status:      200,
+				contentType: "application/x-www-form-urlencoded; charset=utf-8",
+			},
+			want: &FormResponse{
+				StatusCode: 200,
+				requestURI: "https://example.com/oauth",
+				values: url.Values{
+					"access_token": {"123abc"},
+					"scopes":       {"repo gist"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success JSON",
+			args: args{
+				url: "https://example.com/oauth",
+			},
+			http: apiClient{
+				body:        `{"access_token":"123abc", "scopes":"repo gist"}`,
+				status:      200,
+				contentType: "application/json; charset=utf-8",
+			},
+			want: &FormResponse{
+				StatusCode: 200,
+				requestURI: "https://example.com/oauth",
+				values: url.Values{
+					"access_token": {"123abc"},
+					"scopes":       {"repo gist"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "HTML response",
+			args: args{
+				url: "https://example.com/oauth",
+			},
+			http: apiClient{
+				body:        "<h1>Something went wrong</h1>",
+				status:      502,
+				contentType: "text/html",
+			},
+			want: &FormResponse{
+				StatusCode: 502,
+				requestURI: "https://example.com/oauth",
+				values:     url.Values(nil),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PostForm(&tt.http, tt.args.url, tt.args.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PostForm() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.http.postCount != 1 {
+				t.Errorf("expected PostForm to happen 1 time; happened %d times", tt.http.postCount)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PostForm() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/oauth/device/device_flow.go
+++ b/pkg/oauth/device/device_flow.go
@@ -1,0 +1,193 @@
+// Package device facilitates performing OAuth Device Authorization Flow for client applications
+// such as CLIs that can not receive redirects from a web site.
+//
+// First, RequestCode should be used to obtain a CodeResponse.
+//
+// Next, the user will need to navigate to VerificationURI in their web browser on any device and fill
+// in the UserCode.
+//
+// While the user is completing the web flow, the application should invoke PollToken, which blocks
+// the goroutine until the user has authorized the app on the server.
+//
+// https://docs.github.com/en/free-pro-team@latest/developers/apps/authorizing-oauth-apps#device-flow
+package device
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/reubenmiller/go-c8y/pkg/oauth/api"
+)
+
+var (
+	// ErrUnsupported is thrown when the server does not implement Device flow.
+	ErrUnsupported = errors.New("device flow not supported")
+	// ErrTimeout is thrown when polling the server for the granted token has timed out.
+	ErrTimeout = errors.New("authentication timed out")
+)
+
+type httpClient interface {
+	PostForm(string, url.Values) (*http.Response, error)
+}
+
+// CodeResponse holds information about the authorization-in-progress.
+type CodeResponse struct {
+	// The user verification code is displayed on the device so the user can enter the code in a browser.
+	UserCode string
+	// The verification URL where users need to enter the UserCode.
+	VerificationURI string
+	// The optional verification URL that includes the UserCode.
+	VerificationURIComplete string
+
+	// The device verification code is 40 characters and used to verify the device.
+	DeviceCode string
+	// The number of seconds before the DeviceCode and UserCode expire.
+	ExpiresIn int
+	// The minimum number of seconds that must pass before you can make a new access token request to
+	// complete the device authorization.
+	Interval int
+}
+
+// AuthRequestEditorFn defines the function signature for setting additional form values.
+type AuthRequestEditorFn func(*url.Values)
+
+// WithAudience sets the audience parameter in the request.
+func WithAudience(audience string) AuthRequestEditorFn {
+	return func(values *url.Values) {
+		if audience != "" {
+			values.Add("audience", audience)
+		}
+	}
+}
+
+// RequestCode initiates the authorization flow by requesting a code from uri.
+func RequestCode(c httpClient, uri string, clientID string, scopes []string,
+	optionalRequestParams ...AuthRequestEditorFn) (*CodeResponse, error) {
+	values := url.Values{
+		"client_id": {clientID},
+		"scope":     {strings.Join(scopes, " ")},
+	}
+
+	for _, fn := range optionalRequestParams {
+		fn(&values)
+	}
+
+	resp, err := api.PostForm(c, uri, values)
+	if err != nil {
+		return nil, err
+	}
+
+	verificationURI := resp.Get("verification_uri")
+	if verificationURI == "" {
+		// Google's "OAuth 2.0 for TV and Limited-Input Device Applications" uses `verification_url`.
+		verificationURI = resp.Get("verification_url")
+	}
+
+	if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 404 || resp.StatusCode == 422 ||
+		(resp.StatusCode == 200 && verificationURI == "") ||
+		(resp.StatusCode == 400 && resp.Get("error") == "device_flow_disabled") ||
+		(resp.StatusCode == 400 && resp.Get("error") == "unauthorized_client") {
+		return nil, ErrUnsupported
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, resp.Err()
+	}
+
+	intervalSeconds, err := strconv.Atoi(resp.Get("interval"))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse interval=%q as integer: %w", resp.Get("interval"), err)
+	}
+
+	expiresIn, err := strconv.Atoi(resp.Get("expires_in"))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse expires_in=%q as integer: %w", resp.Get("expires_in"), err)
+	}
+
+	return &CodeResponse{
+		DeviceCode:              resp.Get("device_code"),
+		UserCode:                resp.Get("user_code"),
+		VerificationURI:         verificationURI,
+		VerificationURIComplete: resp.Get("verification_uri_complete"),
+		Interval:                intervalSeconds,
+		ExpiresIn:               expiresIn,
+	}, nil
+}
+
+const defaultGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+// PollToken polls the server at pollURL until an access token is granted or denied.
+//
+// Deprecated: use Wait.
+func PollToken(c httpClient, pollURL string, clientID string, code *CodeResponse) (*api.AccessToken, error) {
+	return Wait(context.Background(), c, pollURL, WaitOptions{
+		ClientID:   clientID,
+		DeviceCode: code,
+	})
+}
+
+// WaitOptions specifies parameters to poll the server with until authentication completes.
+type WaitOptions struct {
+	// ClientID is the app client ID value.
+	ClientID string
+	// ClientSecret is the app client secret value. Optional: only pass if the server requires it.
+	ClientSecret string
+	// DeviceCode is the value obtained from RequestCode.
+	DeviceCode *CodeResponse
+	// GrantType overrides the default value specified by OAuth 2.0 Device Code. Optional.
+	GrantType string
+
+	newPoller pollerFactory
+}
+
+// Wait polls the server at uri until authorization completes.
+func Wait(ctx context.Context, c httpClient, uri string, opts WaitOptions) (*api.AccessToken, error) {
+	checkInterval := time.Duration(opts.DeviceCode.Interval) * time.Second
+	expiresIn := time.Duration(opts.DeviceCode.ExpiresIn) * time.Second
+	grantType := opts.GrantType
+	if opts.GrantType == "" {
+		grantType = defaultGrantType
+	}
+
+	makePoller := opts.newPoller
+	if makePoller == nil {
+		makePoller = newPoller
+	}
+	_, poll := makePoller(ctx, checkInterval, expiresIn)
+
+	for {
+		if err := poll.Wait(); err != nil {
+			return nil, err
+		}
+
+		values := url.Values{
+			"client_id":   {opts.ClientID},
+			"device_code": {opts.DeviceCode.DeviceCode},
+			"grant_type":  {grantType},
+		}
+
+		// Google's "OAuth 2.0 for TV and Limited-Input Device Applications" requires `client_secret`.
+		if opts.ClientSecret != "" {
+			values.Add("client_secret", opts.ClientSecret)
+		}
+
+		resp, err := api.PostForm(c, uri, values)
+		if err != nil {
+			return nil, err
+		}
+
+		var apiError *api.Error
+		token, err := resp.AccessToken()
+		if err == nil {
+			return token, nil
+		} else if !(errors.As(err, &apiError) && apiError.Code == "authorization_pending") {
+			return nil, err
+		}
+	}
+}

--- a/pkg/oauth/device/device_flow_test.go
+++ b/pkg/oauth/device/device_flow_test.go
@@ -1,0 +1,535 @@
+package device
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/reubenmiller/go-c8y/pkg/oauth/api"
+)
+
+type apiStub struct {
+	status      int
+	body        string
+	contentType string
+}
+
+type postArgs struct {
+	url    string
+	params url.Values
+}
+
+type apiClient struct {
+	stubs []apiStub
+	calls []postArgs
+
+	postCount int
+}
+
+func (c *apiClient) PostForm(u string, params url.Values) (*http.Response, error) {
+	stub := c.stubs[c.postCount]
+	c.calls = append(c.calls, postArgs{url: u, params: params})
+	c.postCount++
+	return &http.Response{
+		Body: io.NopCloser(bytes.NewBufferString(stub.body)),
+		Header: http.Header{
+			"Content-Type": {stub.contentType},
+		},
+		StatusCode: stub.status,
+	}, nil
+}
+
+func TestRequestCode(t *testing.T) {
+	type args struct {
+		http     apiClient
+		url      string
+		clientID string
+		scopes   []string
+		audience string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *CodeResponse
+		wantErr string
+		posts   []postArgs
+	}{
+		{
+			name: "success",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "verification_uri=http://verify.me&interval=5&expires_in=99&device_code=DEVICE&user_code=123-abc",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url:      "https://example.com/oauth",
+				clientID: "CLIENT-ID",
+				scopes:   []string{"repo", "gist"},
+			},
+			want: &CodeResponse{
+				DeviceCode:      "DEVICE",
+				UserCode:        "123-abc",
+				VerificationURI: "http://verify.me",
+				ExpiresIn:       99,
+				Interval:        5,
+			},
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id": {"CLIENT-ID"},
+						"scope":     {"repo gist"},
+					},
+				},
+			},
+		},
+		{
+			name: "with verification_uri_complete",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "verification_uri=http://verify.me&interval=5&expires_in=99&device_code=DEVICE&user_code=123-abc&verification_uri_complete=http://verify.me/?code=123-abc",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url:      "https://example.com/oauth",
+				clientID: "CLIENT-ID",
+				scopes:   []string{"repo", "gist"},
+			},
+			want: &CodeResponse{
+				DeviceCode:              "DEVICE",
+				UserCode:                "123-abc",
+				VerificationURI:         "http://verify.me",
+				VerificationURIComplete: "http://verify.me/?code=123-abc",
+				ExpiresIn:               99,
+				Interval:                5,
+			},
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id": {"CLIENT-ID"},
+						"scope":     {"repo gist"},
+					},
+				},
+			},
+		},
+		{
+			name: "with audience",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "verification_uri=http://verify.me&interval=5&expires_in=99&device_code=DEVICE&user_code=123-abc&verification_uri_complete=http://verify.me/?code=123-abc",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url:      "https://example.com/oauth",
+				clientID: "CLIENT-ID",
+				scopes:   []string{"repo", "gist"},
+				audience: "cumulocity",
+			},
+			want: &CodeResponse{
+				DeviceCode:              "DEVICE",
+				UserCode:                "123-abc",
+				VerificationURI:         "http://verify.me",
+				VerificationURIComplete: "http://verify.me/?code=123-abc",
+				ExpiresIn:               99,
+				Interval:                5,
+			},
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id": {"CLIENT-ID"},
+						"scope":     {"repo gist"},
+						"audience":  {"cumulocity"},
+					},
+				},
+			},
+		},
+		{
+			name: "unsupported",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "",
+							status:      404,
+							contentType: "text/html",
+						},
+					},
+				},
+				url:      "https://example.com/oauth",
+				clientID: "CLIENT-ID",
+				scopes:   []string{"repo", "gist"},
+			},
+			wantErr: "device flow not supported",
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id": {"CLIENT-ID"},
+						"scope":     {"repo gist"},
+					},
+				},
+			},
+		},
+		{
+			name: "unauthorized client",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "error=unauthorized_client",
+							status:      400,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url:      "https://example.com/oauth",
+				clientID: "CLIENT-ID",
+				scopes:   []string{"repo", "gist"},
+			},
+			wantErr: "device flow not supported",
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id": {"CLIENT-ID"},
+						"scope":     {"repo gist"},
+					},
+				},
+			},
+		},
+		{
+			name: "device flow disabled",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "error=device_flow_disabled",
+							status:      400,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url:      "https://example.com/oauth",
+				clientID: "CLIENT-ID",
+				scopes:   []string{"repo", "gist"},
+			},
+			wantErr: "device flow not supported",
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id": {"CLIENT-ID"},
+						"scope":     {"repo gist"},
+					},
+				},
+			},
+		},
+		{
+			name: "server error",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "<h1>Something went wrong</h1>",
+							status:      502,
+							contentType: "text/html",
+						},
+					},
+				},
+				url:      "https://example.com/oauth",
+				clientID: "CLIENT-ID",
+				scopes:   []string{"repo", "gist"},
+			},
+			wantErr: "HTTP 502",
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id": {"CLIENT-ID"},
+						"scope":     {"repo gist"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RequestCode(&tt.args.http, tt.args.url,
+				tt.args.clientID, tt.args.scopes, WithAudience(tt.args.audience))
+			if (err != nil) != (tt.wantErr != "") {
+				t.Errorf("RequestCode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("error = %q, want %q", err.Error(), tt.wantErr)
+			}
+			if tt.args.http.postCount != 1 {
+				t.Errorf("expected PostForm to happen 1 time; happened %d times", tt.args.http.postCount)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RequestCode() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.args.http.calls, tt.posts) {
+				t.Errorf("PostForm() = %v, want %v", tt.args.http.calls, tt.posts)
+			}
+		})
+	}
+}
+
+func TestPollToken(t *testing.T) {
+	makeFakePoller := func(maxWaits int) pollerFactory {
+		return func(ctx context.Context, interval, expiresIn time.Duration) (context.Context, poller) {
+			return ctx, &fakePoller{maxWaits: maxWaits}
+		}
+	}
+
+	type args struct {
+		http apiClient
+		url  string
+		opts WaitOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *api.AccessToken
+		wantErr string
+		posts   []postArgs
+		slept   time.Duration
+	}{
+		{
+			name: "success",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "error=authorization_pending",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+						{
+							body:        "access_token=123abc",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url: "https://example.com/oauth",
+				opts: WaitOptions{
+					ClientID: "CLIENT-ID",
+					DeviceCode: &CodeResponse{
+						DeviceCode:      "DEVICE",
+						UserCode:        "123-abc",
+						VerificationURI: "http://verify.me",
+						ExpiresIn:       99,
+						Interval:        5,
+					},
+					newPoller: makeFakePoller(2),
+				},
+			},
+			want: &api.AccessToken{
+				Token: "123abc",
+			},
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id":   {"CLIENT-ID"},
+						"device_code": {"DEVICE"},
+						"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+					},
+				},
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id":   {"CLIENT-ID"},
+						"device_code": {"DEVICE"},
+						"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+					},
+				},
+			},
+		},
+		{
+			name: "with client secret and grant type",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "access_token=123abc",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url: "https://example.com/oauth",
+				opts: WaitOptions{
+					ClientID:     "CLIENT-ID",
+					ClientSecret: "ABCDEF",
+					GrantType:    "device_code",
+					DeviceCode: &CodeResponse{
+						DeviceCode:      "DEVICE",
+						UserCode:        "123-abc",
+						VerificationURI: "http://verify.me",
+						ExpiresIn:       99,
+						Interval:        5,
+					},
+					newPoller: makeFakePoller(1),
+				},
+			},
+			want: &api.AccessToken{
+				Token: "123abc",
+			},
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id":     {"CLIENT-ID"},
+						"client_secret": {"ABCDEF"},
+						"device_code":   {"DEVICE"},
+						"grant_type":    {"device_code"},
+					},
+				},
+			},
+		},
+		{
+			name: "timed out",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "error=authorization_pending",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+						{
+							body:        "error=authorization_pending",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url: "https://example.com/oauth",
+				opts: WaitOptions{
+					ClientID: "CLIENT-ID",
+					DeviceCode: &CodeResponse{
+						DeviceCode:      "DEVICE",
+						UserCode:        "123-abc",
+						VerificationURI: "http://verify.me",
+						ExpiresIn:       14,
+						Interval:        5,
+					},
+					newPoller: makeFakePoller(2),
+				},
+			},
+			wantErr: "context deadline exceeded",
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id":   {"CLIENT-ID"},
+						"device_code": {"DEVICE"},
+						"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+					},
+				},
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id":   {"CLIENT-ID"},
+						"device_code": {"DEVICE"},
+						"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+					},
+				},
+			},
+		},
+		{
+			name: "access denied",
+			args: args{
+				http: apiClient{
+					stubs: []apiStub{
+						{
+							body:        "error=access_denied",
+							status:      200,
+							contentType: "application/x-www-form-urlencoded; charset=utf-8",
+						},
+					},
+				},
+				url: "https://example.com/oauth",
+				opts: WaitOptions{
+					ClientID: "CLIENT-ID",
+					DeviceCode: &CodeResponse{
+						DeviceCode:      "DEVICE",
+						UserCode:        "123-abc",
+						VerificationURI: "http://verify.me",
+						ExpiresIn:       99,
+						Interval:        5,
+					},
+					newPoller: makeFakePoller(1),
+				},
+			},
+			wantErr: "access_denied",
+			posts: []postArgs{
+				{
+					url: "https://example.com/oauth",
+					params: url.Values{
+						"client_id":   {"CLIENT-ID"},
+						"device_code": {"DEVICE"},
+						"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Wait(context.Background(), &tt.args.http, tt.args.url, tt.args.opts)
+			if (err != nil) != (tt.wantErr != "") {
+				t.Errorf("PollToken() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("PollToken error = %q, want %q", err.Error(), tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PollToken() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.args.http.calls, tt.posts) {
+				t.Errorf("PostForm() = %v, want %v", tt.args.http.calls, tt.posts)
+			}
+		})
+	}
+}
+
+type fakePoller struct {
+	maxWaits int
+	count    int
+}
+
+func (p *fakePoller) Wait() error {
+	if p.count == p.maxWaits {
+		return errors.New("context deadline exceeded")
+	}
+	p.count++
+	return nil
+}
+
+func (p *fakePoller) Cancel() {
+}

--- a/pkg/oauth/device/example_test.go
+++ b/pkg/oauth/device/example_test.go
@@ -1,0 +1,42 @@
+package device_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/reubenmiller/go-c8y/pkg/oauth/device"
+)
+
+// This demonstrates how to perform OAuth Device Authorization Flow for GitHub.com.
+// After RequestCode successfully completes, the client app should prompt the user to copy
+// the UserCode and to open VerificationURI in their web browser to enter the code.
+func ExampleRequestCode() {
+
+	// client := createTestClient()
+
+	// GetLoginOptions
+
+	clientID := os.Getenv("OAUTH_CLIENT_ID")
+	scopes := []string{"repo", "read:org"}
+	httpClient := http.DefaultClient
+
+	code, err := device.RequestCode(httpClient, "https://github.com/login/device/code", clientID, scopes)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Copy code: %s\n", code.UserCode)
+	fmt.Printf("then open: %s\n", code.VerificationURI)
+
+	accessToken, err := device.Wait(context.TODO(), httpClient, "https://github.com/login/oauth/access_token", device.WaitOptions{
+		ClientID:   clientID,
+		DeviceCode: code,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Access token: %s\n", accessToken.Token)
+}

--- a/pkg/oauth/device/poller.go
+++ b/pkg/oauth/device/poller.go
@@ -1,0 +1,43 @@
+package device
+
+import (
+	"context"
+	"time"
+)
+
+type poller interface {
+	Wait() error
+	Cancel()
+}
+
+type pollerFactory func(context.Context, time.Duration, time.Duration) (context.Context, poller)
+
+func newPoller(ctx context.Context, checkInterval, expiresIn time.Duration) (context.Context, poller) {
+	c, cancel := context.WithTimeout(ctx, expiresIn)
+	return c, &intervalPoller{
+		ctx:        c,
+		interval:   checkInterval,
+		cancelFunc: cancel,
+	}
+}
+
+type intervalPoller struct {
+	ctx        context.Context
+	interval   time.Duration
+	cancelFunc func()
+}
+
+func (p intervalPoller) Wait() error {
+	t := time.NewTimer(p.interval)
+	select {
+	case <-p.ctx.Done():
+		t.Stop()
+		return p.ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+func (p intervalPoller) Cancel() {
+	p.cancelFunc()
+}


### PR DESCRIPTION
Add functions to make it possible to login using oauth2 device authorization flow.

Note: It requires the tenant to have an external OAUTH2 provider configured and enabled to support device flow, and the Cumulocity tenant config must have the external token option enabled