### PR TITLE
fix: allow users to control the displaying of the device code

### DIFF
--- a/examples/device-flow/main.go
+++ b/examples/device-flow/main.go
@@ -32,14 +32,10 @@ func main() {
 	_, err = client.Tenant.AuthorizeWithDeviceFlow(context.Background(), loginOption.InitRequest, api.AuthEndpoints{
 		DeviceAuthorizationURL: "/oauth/device/code",
 		TokenURL:               "/oauth/token",
-	})
+	}, nil)
 	if err != nil {
 		log.Fatalf("Failed to get access token. %s", err)
 	}
-
-	// Verify
-	// client.SetToken(token.Token)
-	// client.AuthorizationMethod = c8y.AuthMethodOAuth2
 
 	fmt.Fprintf(os.Stderr, "🔍 Checking if the token can be used to make API calls\n")
 	_, _, err = client.Alarm.GetAlarms(

--- a/pkg/oauth/device/device_flow.go
+++ b/pkg/oauth/device/device_flow.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -31,6 +32,20 @@ var (
 	// ErrTimeout is thrown when polling the server for the granted token has timed out.
 	ErrTimeout = errors.New("authentication timed out")
 )
+
+type DeviceCodeFunc func(*CodeResponse) error
+
+func DeviceCodeOnConsole(w io.Writer) DeviceCodeFunc {
+	return func(code *CodeResponse) error {
+		var err error
+		if code.VerificationURIComplete != "" {
+			_, err = fmt.Fprintf(w, "Open url: %s\n\n", code.VerificationURIComplete)
+		} else {
+			_, err = fmt.Fprintf(w, "Copy code: %s\nthen open: %s\n\n", code.UserCode, code.VerificationURI)
+		}
+		return err
+	}
+}
 
 type httpClient interface {
 	PostForm(string, url.Values) (*http.Response, error)


### PR DESCRIPTION
Allow users to pass a display function to display the device authorization code which requires user-interaction