### PR TITLE
fix: detect oauth2 device flow endpoints using open-id endpoint

### DIFF
--- a/examples/device-flow/main.go
+++ b/examples/device-flow/main.go
@@ -29,10 +29,7 @@ func main() {
 
 	// Request token using device flow
 	fmt.Fprintf(os.Stderr, "🏄 Signing in using OAuth2 device flow\n\n")
-	_, err = client.Tenant.AuthorizeWithDeviceFlow(context.Background(), loginOption.InitRequest, api.AuthEndpoints{
-		DeviceAuthorizationURL: "/oauth/device/code",
-		TokenURL:               "/oauth/token",
-	}, nil)
+	_, err = client.Tenant.AuthorizeWithDeviceFlow(context.Background(), loginOption.InitRequest, api.AuthEndpoints{}, nil)
 	if err != nil {
 		log.Fatalf("Failed to get access token. %s", err)
 	}

--- a/pkg/oauth/api/endpoint.go
+++ b/pkg/oauth/api/endpoint.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 )
@@ -31,9 +30,19 @@ type AuthEndpoints struct {
 }
 
 // GetEndpointUrl get the full url related to a given oauth endpoint
-func GetEndpointUrl(endpoint *AuthorizationRequest, u string) string {
+func GetEndpointUrl(endpoint *url.URL, u string) string {
 	if endpoint == nil {
 		return u
 	}
-	return fmt.Sprintf("%s://%s/%s", endpoint.URL.Scheme, endpoint.URL.Host, strings.TrimLeft(u, "/"))
+
+	// check if already a fully formed url
+	if strings.Contains(u, "://") {
+		return u
+	}
+
+	out, err := endpoint.Parse(u)
+	if err != nil {
+		return u
+	}
+	return out.String()
 }

--- a/pkg/oauth/api/openid.go
+++ b/pkg/oauth/api/openid.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type OpenIDConfiguration struct {
+	Issuer                      string   `json:"issuer"`
+	AuthorizationEndpoint       string   `json:"authorization_endpoint"`
+	DeviceAuthorizationEndpoint string   `json:"device_authorization_endpoint"`
+	TokenEndpoint               string   `json:"token_endpoint"`
+	UserInfoEndpoint            string   `json:"userinfo_endpoint"`
+	JwksUri                     string   `json:"jwks_uri"`
+	RegistrationEndpoint        string   `json:"registration_endpoint"`
+	RevocationEndpoint          string   `json:"revocation_endpoint"`
+	ResponseTypesSupported      []string `json:"response_types_supported"`
+}
+
+func GetOpenIDConfiguration(ctx context.Context, client *http.Client, oauthUrl *url.URL, data any) error {
+	u, err := oauthUrl.Parse("/.well-known/openid-configuration")
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// Disable redirects so we can capture the first redirect location
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 399 {
+		return fmt.Errorf("openid-configuration request failed. status_code=%s", resp.Status)
+	}
+	defer resp.Body.Close()
+	return json.NewDecoder(resp.Body).Decode(data)
+}


### PR DESCRIPTION
If no oauth2 endpoints are given by the user, try to retrieve the values using the open-id endpoint (if it exists)