### PR TITLE
refactor!: refactor client authorization

### DIFF
--- a/examples/notification2-client-cli/main.go
+++ b/examples/notification2-client-cli/main.go
@@ -34,7 +34,6 @@ func main() {
 	c8yToken := os.Getenv("C8Y_TOKEN")
 	if c8yToken != "" {
 		client.SetToken(c8yToken)
-		client.AuthorizationMethod = c8y.AuthMethodOAuth2Internal
 	}
 
 	notificationClient, err := client.Notification2.CreateClient(context.Background(), c8y.Notification2ClientOptions{

--- a/pkg/c8y/enrollment.go
+++ b/pkg/c8y/enrollment.go
@@ -50,12 +50,12 @@ func (s *DeviceEnrollmentService) Enroll(ctx context.Context, externalID string,
 	headers.Add("Authorization", NewBasicAuthString("", externalID, oneTimePassword))
 
 	resp, err := s.client.SendRequest(ctx, RequestOptions{
-		Method:           "POST",
-		Path:             ".well-known/est/simpleenroll",
-		Header:           headers,
-		ContentType:      "application/pkcs10",
-		Body:             base64.StdEncoding.EncodeToString(csr.Raw),
-		NoAuthentication: true,
+		Method:      "POST",
+		Path:        ".well-known/est/simpleenroll",
+		Header:      headers,
+		ContentType: "application/pkcs10",
+		Body:        base64.StdEncoding.EncodeToString(csr.Raw),
+		AuthFunc:    WithNoAuthorization(),
 	})
 
 	if err != nil {
@@ -178,7 +178,7 @@ func (s *DeviceEnrollmentService) RequestAccessToken(ctx context.Context, client
 		ResponseData: data,
 
 		// No auth is required as x509 certificates are being used
-		NoAuthentication: true,
+		AuthFunc: WithNoAuthorization(),
 	})
 	return data, resp, err
 }

--- a/pkg/c8y/tenant.go
+++ b/pkg/c8y/tenant.go
@@ -124,10 +124,10 @@ func (s *TenantService) GetTenantStatisticsSummary(ctx context.Context, opt *Ten
 func (s *TenantService) GetLoginOptions(ctx context.Context) (*TenantLoginOptions, *Response, error) {
 	data := new(TenantLoginOptions)
 	resp, err := s.client.SendRequest(ctx, RequestOptions{
-		Method:           "GET",
-		Path:             "tenant/loginOptions",
-		NoAuthentication: true,
-		ResponseData:     data,
+		Method:       "GET",
+		Path:         "tenant/loginOptions",
+		AuthFunc:     WithNoAuthorization(),
+		ResponseData: data,
 	})
 	return data, resp, err
 }
@@ -377,7 +377,7 @@ func (s *TenantService) HasExternalAuthProvider(ctx context.Context) (loginOptio
 	}
 
 	for _, option := range loginOptions.LoginOptions {
-		if option.Type == AuthMethodOAuth2 {
+		if option.Type == LoginTypeOAuth2 {
 			loginOption = &option
 			found = true
 			break
@@ -443,7 +443,6 @@ func (s *TenantService) AuthorizeWithDeviceFlow(ctx context.Context, initRequest
 	// Update client auth
 	Logger.Info("Using token from device flow")
 	s.client.SetToken(accessToken.Token)
-	s.client.AuthorizationMethod = AuthMethodOAuth2
 
 	return accessToken, nil
 }

--- a/pkg/c8ytestutils/c8ytestutils.go
+++ b/pkg/c8ytestutils/c8ytestutils.go
@@ -69,7 +69,6 @@ func (s *SetupConfiguration) NewClient() *c8y.Client {
 
 	if token != "" {
 		client.SetToken(token)
-		client.AuthorizationMethod = c8y.AuthMethodOAuth2Internal
 	}
 	return client
 }


### PR DESCRIPTION
Change the authorization mechanisms and naming to be more consistent with its function.

* RequestOptions no longer has "NoAuthentication". Instead use `AuthFunc:    WithNoAuthorization(),`.
* Setting the AuthorizationMethod is no longer required, and th e
* Split AuthorizationType (e.g. BASIC, BEARER) and LoginType (OAUTH2, OAUTH2_INTERNAL, BASIC (username/password).
