### PR TITLE
fix: return the error if the open id connect configuration url files

### DIFF
--- a/pkg/c8y/tenant.go
+++ b/pkg/c8y/tenant.go
@@ -407,9 +407,9 @@ func (s *TenantService) AuthorizeWithDeviceFlow(ctx context.Context, initRequest
 		// Try detecting the endpoints via the open-id configuration endpoint
 		openIDConfig := &api.OpenIDConfiguration{}
 		if err := api.GetOpenIDConfiguration(ctx, httpClient, endpoint.URL, auth_endpoints.OpenIDConfigurationURL, openIDConfig); err != nil {
-			Logger.Infof("Could not get open-id configuration. url=%s, err=%s", endpoint.URL.String(), err)
+			return nil, fmt.Errorf("could not get OpenID Connect configuration. url=%s, err=%s", endpoint.URL.String(), err)
 		} else {
-			Logger.Infof("Found open-id configuration. url=%s, config=%#v", endpoint.URL.String(), openIDConfig)
+			Logger.Infof("Found OpenID Connect configuration. url=%s, config=%#v", endpoint.URL.String(), openIDConfig)
 			if auth_endpoints.TokenURL == "" {
 				auth_endpoints.TokenURL = openIDConfig.TokenEndpoint
 			}


### PR DESCRIPTION
Propogate the error back to the caller if the given configuration URL fails