### PR TITLE
fix: add error type for invalid open-id configuration

### DIFF
--- a/pkg/c8y/tenant.go
+++ b/pkg/c8y/tenant.go
@@ -2,6 +2,7 @@ package c8y
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"github.com/reubenmiller/go-c8y/pkg/oauth/api"
 	"github.com/reubenmiller/go-c8y/pkg/oauth/device"
 )
+
+var ErrSSOInvalidConfiguration = errors.New("invalid sso configuration")
 
 // TenantService does something
 type TenantService service
@@ -418,7 +421,7 @@ func (s *TenantService) AuthorizeWithDeviceFlow(ctx context.Context, initRequest
 		}
 
 		if err := api.GetOpenIDConfiguration(ctx, httpClient, endpoint.URL, auth_endpoints.OpenIDConfigurationURL, openIDConfig); err != nil {
-			return nil, fmt.Errorf("could not get OpenID Connect configuration. url=%s, err=%s", auth_endpoints.OpenIDConfigurationURL, err)
+			return nil, fmt.Errorf("%w. %w", ErrSSOInvalidConfiguration, err)
 		} else {
 			Logger.Infof("Found OpenID Connect configuration. url=%s, config=%#v", auth_endpoints.OpenIDConfigurationURL, openIDConfig)
 			if auth_endpoints.TokenURL == "" {

--- a/pkg/oauth/api/openid.go
+++ b/pkg/oauth/api/openid.go
@@ -97,7 +97,7 @@ func GetOpenIDConfiguration(ctx context.Context, client *http.Client, oauthUrl *
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 399 {
-		return fmt.Errorf("openid-configuration request failed. status_code=%s", resp.Status)
+		return fmt.Errorf("request failed. status_code=%s, url=%s", resp.Status, u.String())
 	}
 	defer resp.Body.Close()
 	return json.NewDecoder(resp.Body).Decode(data)


### PR DESCRIPTION
Allow users to catch sso configuration errors