### PR TITLE
fix: allow users to configure the sso audience

### DIFF
--- a/pkg/c8y/tenant.go
+++ b/pkg/c8y/tenant.go
@@ -400,6 +400,7 @@ func (s *TenantService) AuthorizeWithDeviceFlow(ctx context.Context, initRequest
 
 	httpClient := NewHTTPClient(
 		WithInsecureSkipVerify(skipVerify),
+		WithRequestDebugLogger(Logger),
 	)
 	endpoint, err := getAuthorizationRequest(ctx, httpClient, initRequest)
 	if err != nil {
@@ -440,8 +441,10 @@ func (s *TenantService) AuthorizeWithDeviceFlow(ctx context.Context, initRequest
 	}
 
 	deviceCodeURL := api.GetEndpointUrl(endpoint.URL, auth_endpoints.DeviceAuthorizationURL)
+	requestCodeOptions := append([]api.AuthRequestEditorFn{}, auth_endpoints.AuthRequestOptions...)
+	requestCodeOptions = append(requestCodeOptions, api.WithAudience(endpoint.Audience))
 	Logger.Infof("Requesting device code. url=%s, client_id=%s, scopes=%v", deviceCodeURL, endpoint.ClientID, scopes)
-	code, err := device.RequestCode(httpClient, deviceCodeURL, endpoint.ClientID, scopes, device.WithAudience(endpoint.Audience))
+	code, err := device.RequestCode(httpClient, deviceCodeURL, endpoint.ClientID, scopes, requestCodeOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/api/endpoint.go
+++ b/pkg/oauth/api/endpoint.go
@@ -32,6 +32,9 @@ type AuthEndpoints struct {
 
 	// User defined scopes to add to request
 	Scopes []string
+
+	// Custom auth request options
+	AuthRequestOptions []AuthRequestEditorFn
 }
 
 // GetEndpointUrl get the full url related to a given oauth endpoint

--- a/pkg/oauth/api/form.go
+++ b/pkg/oauth/api/form.go
@@ -11,6 +11,18 @@ import (
 	"strconv"
 )
 
+// AuthRequestEditorFn defines the function signature for setting additional form values.
+type AuthRequestEditorFn func(*url.Values)
+
+// WithAudience sets the audience parameter in the request.
+func WithAudience(audience string) AuthRequestEditorFn {
+	return func(values *url.Values) {
+		if audience != "" {
+			values.Add("audience", audience)
+		}
+	}
+}
+
 type httpClient interface {
 	PostForm(string, url.Values) (*http.Response, error)
 }

--- a/pkg/oauth/device/device_flow.go
+++ b/pkg/oauth/device/device_flow.go
@@ -69,21 +69,9 @@ type CodeResponse struct {
 	Interval int
 }
 
-// AuthRequestEditorFn defines the function signature for setting additional form values.
-type AuthRequestEditorFn func(*url.Values)
-
-// WithAudience sets the audience parameter in the request.
-func WithAudience(audience string) AuthRequestEditorFn {
-	return func(values *url.Values) {
-		if audience != "" {
-			values.Add("audience", audience)
-		}
-	}
-}
-
 // RequestCode initiates the authorization flow by requesting a code from uri.
 func RequestCode(c httpClient, uri string, clientID string, scopes []string,
-	optionalRequestParams ...AuthRequestEditorFn) (*CodeResponse, error) {
+	optionalRequestParams ...api.AuthRequestEditorFn) (*CodeResponse, error) {
 	values := url.Values{
 		"client_id": {clientID},
 		"scope":     {strings.Join(scopes, " ")},

--- a/pkg/oauth/device/device_flow_test.go
+++ b/pkg/oauth/device/device_flow_test.go
@@ -275,7 +275,7 @@ func TestRequestCode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := RequestCode(&tt.args.http, tt.args.url,
-				tt.args.clientID, tt.args.scopes, WithAudience(tt.args.audience))
+				tt.args.clientID, tt.args.scopes, api.WithAudience(tt.args.audience))
 			if (err != nil) != (tt.wantErr != "") {
 				t.Errorf("RequestCode() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Allow the SSO audience to be set when requesting the device code, and support setting other custom options.