### PR TITLE
fix(notification2): fix notification2 websocket tls detection

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -96,5 +96,6 @@
         "tidwall",
         "vbauerster",
         "wsconnadapter",
+        "wsurl",
     ],
 }

--- a/pkg/c8y/notification2/notification2.go
+++ b/pkg/c8y/notification2/notification2.go
@@ -7,12 +7,12 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/reubenmiller/go-c8y/pkg/logger"
+	"github.com/reubenmiller/go-c8y/pkg/wsurl"
 	"github.com/tidwall/gjson"
 	tomb "gopkg.in/tomb.v2"
 )
@@ -124,15 +124,10 @@ func (m *Message) JSON() gjson.Result {
 }
 
 func getEndpoint(host string, subscription Subscription) *url.URL {
-	fullHost := "wss://" + host
-	if index := strings.Index(host, "://"); index > -1 {
-		fullHost = "wss" + host[index:]
-	}
-	tempUrl, err := url.Parse(fullHost)
+	c8yHost, err := wsurl.GetWebsocketURL(host, "notification2/consumer/")
 	if err != nil {
 		Logger.Fatalf("Invalid url. %s", err)
 	}
-	c8yHost := tempUrl.ResolveReference(&url.URL{Path: "notification2/consumer/"})
 	c8yHost.RawQuery = "token=" + subscription.Token
 
 	if subscription.Consumer != "" {

--- a/pkg/c8y/notification2/notification2_test.go
+++ b/pkg/c8y/notification2/notification2_test.go
@@ -20,3 +20,17 @@ CREATE
 	testingutils.Equals(t, "/t123456/measurements/12345", string(message.Description))
 	testingutils.Assert(t, len(message.Payload) > 0, "payload size should be larger than zero")
 }
+
+func Test_GetEndpoint(t *testing.T) {
+	endpoint := getEndpoint("http://cumulocity:8111", Subscription{
+		Token:    "abcdef",
+		Consumer: "",
+	})
+	testingutils.Equals(t, endpoint.Scheme, "ws")
+
+	endpoint = getEndpoint("https://cumulocity:8111", Subscription{
+		Token:    "abcdef",
+		Consumer: "",
+	})
+	testingutils.Equals(t, endpoint.Scheme, "wss")
+}

--- a/pkg/c8y/realtime.go
+++ b/pkg/c8y/realtime.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/obeattie/ohmyglob"
+	"github.com/reubenmiller/go-c8y/pkg/wsurl"
 	"github.com/tidwall/gjson"
 	"golang.org/x/net/publicsuffix"
 	tomb "gopkg.in/tomb.v2"
@@ -180,15 +181,11 @@ func getC8yExtensionFromXSRFToken(token string) c8yExtensionMessage {
 }
 
 func getRealtimeURL(host string) *url.URL {
-	c8yHost, _ := url.Parse(host)
-
-	if c8yHost.Scheme == "http" {
-		c8yHost.Scheme = "ws"
-	} else {
-		c8yHost.Scheme = "wss"
+	c8yHost, err := wsurl.GetWebsocketURL(host, "cep/realtime")
+	if err != nil {
+		Logger.Fatalf("Invalid websocket url. %s", err)
 	}
-
-	return c8yHost.ResolveReference(&url.URL{Path: "cep/realtime"})
+	return c8yHost
 }
 
 // NewRealtimeClient initializes a new Bayeux client. By default `http.DefaultClient`

--- a/pkg/wsurl/wsurl.go
+++ b/pkg/wsurl/wsurl.go
@@ -1,0 +1,27 @@
+package wsurl
+
+import (
+	"net/url"
+	"strings"
+)
+
+func GetWebsocketURL(host string, path string) (*url.URL, error) {
+	if !strings.HasSuffix(host, "/") {
+		host += "/"
+	}
+	if !strings.Contains(host, "://") {
+		host = "wss://" + host
+	}
+	tempUrl, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+
+	if tempUrl.Scheme == "http" {
+		tempUrl.Scheme = "ws"
+	} else {
+		tempUrl.Scheme = "wss"
+	}
+
+	return tempUrl.ResolveReference(&url.URL{Path: path}), nil
+}

--- a/pkg/wsurl/wsurl_test.go
+++ b/pkg/wsurl/wsurl_test.go
@@ -1,0 +1,53 @@
+package wsurl
+
+import (
+	"testing"
+
+	"github.com/reubenmiller/go-c8y/internal/pkg/testingutils"
+)
+
+func Test_GetEndpoint(t *testing.T) {
+	cases := []struct {
+		Host           string
+		Path           string
+		ExpectedScheme string
+		ExpectedHost   string
+		ExpectedPath   string
+	}{
+		{
+			Host:           "http://cumulocity:8111",
+			Path:           "foo/bar",
+			ExpectedScheme: "ws",
+			ExpectedHost:   "cumulocity:8111",
+			ExpectedPath:   "/foo/bar",
+		},
+		{
+			Host:           "https://cumulocity:8111",
+			Path:           "foo/bar",
+			ExpectedScheme: "wss",
+			ExpectedHost:   "cumulocity:8111",
+			ExpectedPath:   "/foo/bar",
+		},
+		{
+			Host:           "https://cumulocity:8111/",
+			Path:           "foo/bar",
+			ExpectedScheme: "wss",
+			ExpectedHost:   "cumulocity:8111",
+			ExpectedPath:   "/foo/bar",
+		},
+		{
+			Host:           "https://cumulocity:8111/some/nested",
+			Path:           "foo/bar",
+			ExpectedScheme: "wss",
+			ExpectedHost:   "cumulocity:8111",
+			ExpectedPath:   "/some/nested/foo/bar",
+		},
+	}
+	for _, item := range cases {
+		endpoint, err := GetWebsocketURL(item.Host, item.Path)
+		testingutils.Ok(t, err)
+		testingutils.Equals(t, item.ExpectedScheme, endpoint.Scheme)
+		testingutils.Equals(t, item.ExpectedHost, endpoint.Host)
+		testingutils.Equals(t, item.ExpectedPath, endpoint.Path)
+	}
+}


### PR DESCRIPTION
Fix a bug where the notifiction2 websocket url was always assumed it is a TLS connection (e.g. `wss://`).