### PR TITLE
feat(certificate-authority): support certificateAuthority query parameter when filtering the trusted certificates

### DIFF
--- a/pkg/c8y/certificateAuthority.go
+++ b/pkg/c8y/certificateAuthority.go
@@ -83,13 +83,14 @@ func (s *CertificateAuthorityService) Delete(ctx context.Context, fingerprint st
 
 // Get certificate authority for the current tenant
 func (s *CertificateAuthorityService) Get(ctx context.Context) (*Certificate, error) {
-	paginationOptions := PaginationOptions{
-		PageSize:          2000,
-		WithTotalElements: true,
+	options := &DeviceCertificateCollectionOptions{
+		PaginationOptions: PaginationOptions{
+			PageSize:          5,
+			WithTotalElements: true,
+		},
 	}
-	items, resp, err := s.client.DeviceCertificate.GetCertificates(ctx, s.client.GetTenantName(ctx), &DeviceCertificateCollectionOptions{
-		PaginationOptions: paginationOptions,
-	})
+	options.WithCertificateAuthority(true)
+	items, resp, err := s.client.DeviceCertificate.GetCertificates(ctx, s.client.GetTenantName(ctx), options)
 	if err != nil {
 		return nil, err
 	}
@@ -97,10 +98,8 @@ func (s *CertificateAuthorityService) Get(ctx context.Context) (*Certificate, er
 		return nil, nil
 	}
 
-	for _, item := range items.Certificates {
-		if item.TenantCertificateAuthority {
-			return &item, nil
-		}
+	if len(items.Certificates) > 0 {
+		return &items.Certificates[0], nil
 	}
 	return nil, ErrNotFound
 }

--- a/pkg/c8y/deviceCertificate.go
+++ b/pkg/c8y/deviceCertificate.go
@@ -18,6 +18,14 @@ type DeviceCertificateService service
 type DeviceCertificateCollectionOptions struct {
 	// Pagination options
 	PaginationOptions
+
+	// Only return the Cumulocity Certificate Authority certificate
+	CertificateAuthority *bool `url:"certificateAuthority,omitempty"`
+}
+
+func (o *DeviceCertificateCollectionOptions) WithCertificateAuthority(v bool) *DeviceCertificateCollectionOptions {
+	o.CertificateAuthority = &v
+	return o
 }
 
 // DeviceCertificateCollection a list of the trusted device certificates


### PR DESCRIPTION
Use the newer [certificateAuthority](https://cumulocity.com/api/core/#operation/getTrustedCertificateCollectionResource) query parameter to use server-side filtering when retrieving the Cumulocity Certificate Authority instead of relying on client-side filtering